### PR TITLE
Sanity checks for portals.dm and _internal.dm

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -62,7 +62,7 @@
 var/list/portal_cache = list()
 
 /obj/effect/portal/proc/blend_icon(turf/T)
-	if(!("icon[initial(T.icon)]_iconstate[T.icon_state]_[type]" in portal_cache))//If the icon has not been added yet
+	if(!("icon[initial(T.icon)]_iconstate[T?.icon_state]_[type]" in portal_cache))//If the icon has not been added yet
 		var/icon/I1 = icon(icon,mask)//Generate it.
 		var/icon/I2 = icon(initial(T.icon),T.icon_state)
 		I1.Blend(I2,ICON_MULTIPLY)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -114,7 +114,7 @@
 			if(!LAZYLEN(possible_wounds))
 				break
 
-		owner.custom_pain("Something inside your [parent.name] hurts a lot.", 0)		// Let em know they're hurting
+		owner?.custom_pain("Something inside your [parent.name] hurts a lot.", 0)		// Let em know they're hurting
 
 		return TRUE
 	return FALSE


### PR DESCRIPTION
Fixes
```Runtime in code/game/objects/effects/portals.dm,65: Cannot read null.icon_state```
```Runtime in code/modules/organs/internal/_internal.dm,117: Cannot execute null.custom pain().```
