### PR TITLE
Removes voicelines from Genetics Machinery.

### DIFF
--- a/code/modules/genetics/machinery/genetics_analyzer.dm
+++ b/code/modules/genetics/machinery/genetics_analyzer.dm
@@ -78,7 +78,7 @@ cannot isolate or combine desired genes.
 
 /obj/machinery/genetics/gene_analyzer/attackby(obj/item/I, mob/user)
 	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 80) &&!user.stats?.getPerk(PERK_NERD) && !usr.stat_check(STAT_BIO, 60))
-		to_chat(usr, SPAN_WARNING("The console output is too difficult for you to understand."))"))
+		to_chat(usr, SPAN_WARNING("The console output is too difficult for you to understand."))
 		return
 	if(default_deconstruction(I, user))
 		return

--- a/code/modules/genetics/machinery/genetics_analyzer.dm
+++ b/code/modules/genetics/machinery/genetics_analyzer.dm
@@ -78,7 +78,7 @@ cannot isolate or combine desired genes.
 
 /obj/machinery/genetics/gene_analyzer/attackby(obj/item/I, mob/user)
 	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 80) &&!user.stats?.getPerk(PERK_NERD) && !usr.stat_check(STAT_BIO, 60))
-		to_chat(usr, SPAN_WARNING("The console pityingly suggests: \"Sorry hun, maybe you should get help from a scientist~?\""))
+		to_chat(usr, SPAN_WARNING("The console output is too difficult for you to understand."))"))
 		return
 	if(default_deconstruction(I, user))
 		return
@@ -103,7 +103,7 @@ cannot isolate or combine desired genes.
 
 /obj/machinery/genetics/gene_analyzer/attack_hand(mob/user)
 	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 80) &&!user.stats?.getPerk(PERK_NERD) && !usr.stat_check(STAT_BIO, 60))
-		to_chat(usr, SPAN_WARNING("The console pityingly suggests: \"Sorry hun, maybe you should get help from a scientist~?\""))
+		to_chat(usr, SPAN_WARNING("The console output is too difficult for you to understand."))
 		return
 	if(..())
 		return TRUE
@@ -232,7 +232,7 @@ cannot isolate or combine desired genes.
 					console.files.adjust_research_points(awarding_points) // Give the points
 					var/obj/item/device/radio/radio
 					radio = new /obj/item/device/radio{channels=list("Science")}(src) // Create a new radio
-					radio.autosay("Genetics Research Uploaded, granting [awarding_points] research points~!", "Genetics Announcement System", "Science") // Make the radio say a message.
+					radio.autosay("Genetics Research Uploaded, providing [awarding_points] research points!", "Genetics Announcement System", "Science") // Make the radio say a message.
 					qdel(radio)
 
 				//Update known mutations from the master console JIC

--- a/code/modules/genetics/machinery/genetics_cloner.dm
+++ b/code/modules/genetics/machinery/genetics_cloner.dm
@@ -196,38 +196,38 @@ This makes cloning vat is probably the most dangerous tool in Genetics. Because 
 
 	reader = find_reader()
 	if(!reader)
-		visible_message(SPAN_DANGER("The Cloning Vat says: \"Error, Operations console not detected~!\""))
+		visible_message(SPAN_DANGER("The Cloning Vat says: \"Error, Operations console not detected!\""))
 		return
 	reader_loc = reader.loc
 
 	if(cloning)
-		addLog("Error, Cloning already in progress~!")
+		addLog("Error, Cloning already in progress!")
 		return
 
 	if(embryo)
-		addLog("Error, Please vacate the nonviable embryo from the chamber~!")
+		addLog("Error, Please vacate the nonviable subject from the chamber!")
 		return
 
 	container = find_container()
 	if(!container)
-		addLog("Error, Protein canister not detected~!")
+		addLog("Error, Protein canister not detected!")
 		return
 
 	container_loc = container.loc
 
 	trunk = locate() in src.loc
 	if(!trunk)
-		addLog("Error, Pipe trunk not detected~!")
+		addLog("Error, Pipe trunk not detected!")
 		return
 
 	if(!clone_info)
-		addLog("Error, Genetic Sample Plate not detected~!")
+		addLog("Error, Genetic Sample Plate not detected!")
 		return
 
 	clone_mutation = clone_info.findCloneMutation()
 
 	if(!clone_mutation)
-		addLog("Error, Cloning data not found~!")
+		addLog("Error, Cloning data not found!")
 		return
 
 	progress = 0
@@ -373,24 +373,24 @@ This makes cloning vat is probably the most dangerous tool in Genetics. Because 
 								//TODO: SPECIAL BREAKOUT EVENT
 								breakout()
 						else
-							addLog("Protein not available~, The Embryo has starved.")
+							addLog("Protein not available, the test subject has starved.")
 							stop() //The clone is dead.
 					else if(clone_ready)
 						visible_message(SPAN_DANGER("The creature inside the cloning vat begins to stir..."))
 				else
-					addLog("Protein container not found~, The Embryo has starved.")
+					addLog("Protein container not found, the test subject has starved.")
 					stop()
 			else
 				breakout()
 
 	if (clone_ready && !ready_message)
-		addLog("The Test Subject has Matured~!")
+		addLog("The Test Subject has Matured!")
 		ready_message = TRUE
 		embryo = null
 
 	//Disposal loop
 	if(flush && air_contents.return_pressure() >= SEND_PRESSURE )	// flush can happen even without power
-		addLog("Flushed the Test Subject down the disposal pipe~")
+		addLog("Flushed the Test Subject down the disposal pipe")
 		flush()
 	if(mode != 1) //if off or ready, no need to charge
 		update_use_power(1)
@@ -461,7 +461,7 @@ This makes cloning vat is probably the most dangerous tool in Genetics. Because 
 
 /obj/machinery/genetics/cloner/attackby(obj/item/I, mob/user)
 	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 90) &&!user.stats?.getPerk(PERK_NERD) && !usr.stat_check(STAT_BIO, 180))
-		to_chat(usr, SPAN_WARNING("The console pityingly suggests: \"Sorry hun, you were pressing some weird buttons so I locked you out~ Maybe have a scientist help~?\""))
+		to_chat(usr, SPAN_WARNING("The consle buzzes as you are locked out, displaying a message: "Contact Soteria Genetics personnel for further assistance.""))
 		return
 
 	if(default_deconstruction(I, user))
@@ -671,7 +671,7 @@ and which aren't.
 /obj/machinery/computer/genetics/clone_console/Initialize()
 	. = ..()
 	sync()
-	addLog("Soteria Cloning Vat Console initialized. Welcome~")
+	addLog("Soteria Cloning Vat Console initialized.")
 
 /obj/machinery/computer/genetics/clone_console/proc/addLog(string)
 	cloneLog = "\[[stationtime2text()]\] " + string + "<br>" + cloneLog

--- a/code/modules/genetics/machinery/genetics_extractor.dm
+++ b/code/modules/genetics/machinery/genetics_extractor.dm
@@ -24,7 +24,7 @@
 
 /obj/machinery/genetics/pulper/attackby(obj/item/I, mob/user)
 	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 35) && !user.stats?.getPerk(PERK_NERD) && !usr.stat_check(STAT_BIO, 70)) //So someone that has basic chems or level up can be an assent
-		to_chat(usr, SPAN_WARNING("The console pityingly suggests: \"Sorry hun, maybe you should get help from a scientist~?\""))
+		to_chat(usr, SPAN_WARNING("This machine is too advanced for you to use."))
 		return
 
 	if(default_deconstruction(I, user))
@@ -32,19 +32,19 @@
 	if(default_part_replacement(I, user))
 		return
 	if(stat & (NOPOWER|BROKEN))
-		to_chat(user, SPAN_WARNING("The pulper is inactive and blessedly silent."))
+		to_chat(user, SPAN_WARNING("The pulper is inactive and ominously silent."))
 		return
 	if(pulping)
-		src.visible_message(SPAN_DANGER("The pulper trills: \"The pulper is running~! Please wait for it to finish~\""))
+		src.visible_message(SPAN_DANGER("The pupler is currently running, you have to wait for it to finish."))
 		return
 
 	//Inserting a sample
 	if(istype(I, /obj/item/reagent_containers/snacks/meat))
 		if(meat.len >= 5)
-			src.visible_message(SPAN_WARNING("The pulper says in a sing-song voice: \"The Pulper is full~!\""))
+			src.visible_message(SPAN_WARNING("The pulper is full, please turn it on and process the contents before filling it again."))
 			return
 		if(occupant)
-			src.visible_message(SPAN_WARNING("The pulper sings: \"The Pulper has a whole creature in there, process that first~!\""))
+			src.visible_message(SPAN_WARNING("The pulper is full, please turn it on and process the contents before filling it again."))
 			return
 
 		user.drop_item()
@@ -58,16 +58,16 @@
 
 /obj/machinery/genetics/pulper/affect_grab(mob/user, mob/living/target, state)
 	if(stat & (NOPOWER|BROKEN))
-		to_chat(user, SPAN_WARNING("The pulper is inactive and blessedly silent."))
+		to_chat(user, SPAN_WARNING("The pulper is inactive and ominously silent."))
 		return
 	if(pulping)
-		src.visible_message(SPAN_WARNING("The pulper trills: \"The pulper is running~! Please wait for it to finish~!\""))
+		src.visible_message(SPAN_WARNING("The pupler is currently running, you have to wait for it to finish."))
 		return
 	if(istype(target, /mob/living/carbon/human))
-		src.visible_message(SPAN_WARNING("The pulper chimes in: \"Uh Oh~ Humans aren't allowed in the pulper~!\""))
+		src.visible_message(SPAN_WARNING("The pulper's biosaftey sensors activate and prevent you from putting a human inside it."))
 		return
 	if(meat.len > 0)
-		src.visible_message(SPAN_WARNING("The pulper chuckles: \"Not enough room~! Process the meat inside before adding a whole creature to it~!\""))
+		src.visible_message(SPAN_WARNING("The pulper is full, please turn it on and process the contents before filling it again."))
 		return
 
 	//Check if the creature actually bears meat, IE: It has DNA
@@ -88,7 +88,7 @@
 		temp_meat_type = /obj/item/reagent_containers/snacks/meat
 
 	if(temp_meat_count <= 0)
-		src.visible_message(SPAN_WARNING("The pulper gently reminds: \"That is creature has no genetic material, hun~\""))
+		src.visible_message(SPAN_WARNING("This creature doesn't have any genetic material to extract."))
 
 	//Do the insertion step
 	if(do_after(user, 60, target))
@@ -100,13 +100,13 @@
 
 /obj/machinery/genetics/pulper/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
-		to_chat(user, SPAN_WARNING("The pulper is inactive and blessedly silent."))
+		to_chat(user, SPAN_WARNING("The pulper is inactive and ominously silent."))
 		return
 	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 35) && !user.stats?.getPerk(PERK_NERD) && !usr.stat_check(STAT_BIO, 70)) //So someone that has basic chems or level up can be an assent
-		to_chat(usr, SPAN_WARNING("The console pityingly suggests: \"Sorry hun, maybe you should get help from a scientist~?\""))
+		to_chat(usr, SPAN_WARNING("This machine is too advanced for you to use."))
 		return
 	if(pulping)
-		src.visible_message( SPAN_DANGER("The pulper trills: \"The pulper is running~! Wait for it to finish.\""))
+		src.visible_message( SPAN_DANGER("The pupler is currently running, you have to wait for it to finish."))
 		return
 	else
 		src.startpulping(user)
@@ -130,7 +130,7 @@
 	update_icon()
 	spawn(gib_time) //Escape in time?
 		if(occupant && (occupant.loc == src)  && occupant_meat_count && ispath(occupant_meat_type, /obj/item/reagent_containers/snacks/meat))
-			src.visible_message(SPAN_WARNING("The pulper says ecstatically: \"Pulping~! Creature~!\""))
+			src.visible_message(SPAN_WARNING("The pulper pings as it extracts the genetic material from [occupant]."))
 			//big-range splatter
 			playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
 			var/obj/effect/decal/cleanable/blood/splatter/animated/B = new(src.loc)
@@ -157,7 +157,7 @@
 			occupant_meat_count = 0
 
 		if(meat.len >= 0)
-			src.visible_message(SPAN_WARNING("The pulper says ecstatically: \"Pulping~! Meat~!\""))
+			src.visible_message(SPAN_WARNING("The pulper pings as it extracts the genetic material from the meat."))
 
 			//low-range splatter
 			playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Removes voice lines from the genetics machinery, and streamlines player warnings to be more descriptive for ease of use.
	Removes references to subject as "embryo" outside of code.
	At the request of a few science players, myself, and my sanity.
</summary>
<hr>

This PR removes all voice lines from the pulper and the other genetics machinery, as it has been found to be disconcerting by many of the players that enjoy science's game play loop. I've had two people complain about it, so I've taken the time to remove it and replace it with more descriptive, and thusly, more helpful span warnings, for the sake of our sanity.
	
<hr>
</details>

## Changelog
:cl:
tweak: Removed genetics voice lines and replaced them with descriptive span warnings.
/:cl: