### PR TITLE
Sanity Checks for sa_breath.dm

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/sa_breath.dm
+++ b/code/modules/mob/living/carbon/superior_animal/sa_breath.dm
@@ -11,7 +11,7 @@
 /mob/living/carbon/superior/handle_breath(datum/gas_mixture/environment as anything)
 	var/damage = 0
 	if(breath_required_type)
-		if(environment.gas[breath_required_type] < min_breath_required_type)
+		if(environment?.gas[breath_required_type] < min_breath_required_type)
 			damage = min_breath_required_type - environment.gas[breath_required_type]
 			adjustOxyLoss(damage)
 
@@ -28,7 +28,7 @@
 	return
 
 /mob/living/carbon/superior/handle_environment(datum/gas_mixture/environment as anything)
-	var/pressure = environment.return_pressure()
+	var/pressure = environment?.return_pressure()
 	var/damage = 0
 //	message_admins("pressure = [pressure] temp = [environment.temperature]")
 


### PR DESCRIPTION
## About The Pull Request
Fixes or hides these runtimes:
Runtime in code/modules/mob/living/carbon/superior_animal/sa_breath.dm,14: Cannot read null.gas
Runtime in code/modules/mob/living/carbon/superior_animal/sa_breath.dm,31: Cannot execute null.return pressure().

This may have been caused by the previous sanity check added to sa_breath.dm (https://github.com/epic-new-soj-thing/Sojourn-Iskhod/commit/79c64dc01cdcdc77859e65ccdc215d6b5d93535f), I'll look into it more later, as this could be related to other sanity checks put in due to atmos problems. These checks are being put in partially for testing purposes to see if they cause anything else to happen.

## Changelog
- Added two sanity checks for sa_breath.dm