### PR TITLE
Streamlining and correcting uniform and suit descriptions for jobs

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -99,7 +99,7 @@
 //Quartermaster
 /obj/item/clothing/suit/storage/rank/qm_coat
 	name = "surface manager coat"
-	desc = "An ideal choice for the "businessman". This coat seems have good impact resistance, and is made from resistant and expensive materials."
+	desc = "An ideal choice for the businessman. This coat seems have good impact resistance, and is made from resistant and expensive materials."
 	icon_state = "qm_coat"
 	item_state = "qm_coat"
 	blood_overlay_type = "coat"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -5,7 +5,7 @@
 //Assistant
 /obj/item/clothing/suit/storage/rank/ass_jacket
 	name = "colonist jacket"
-	desc = "Practical and comfortable jacket. It seems have a little protection from physical harm."
+	desc = "Practical and comfortable jacket, padded for an inch of extra protection from harm."
 	icon_state = "ass_jacket"
 	item_state = "ass_jacket"
 	blood_overlay_type = "coat"
@@ -22,7 +22,7 @@
 //Guild Technician
 /obj/item/clothing/suit/storage/rank/cargo_jacket
 	name = "lonestar jacket"
-	desc = "Stylish jacket lined with pockets. It seems have a little protection from physical harm."
+	desc = "Stylish jacket lined with pockets, padded for an inch of extra protection from harm."
 	icon_state = "cargo_jacket"
 	item_state = "cargo_jacket"
 	blood_overlay_type = "coat"
@@ -38,7 +38,7 @@
 
 /obj/item/clothing/suit/storage/rank/cargoclerk_jacket
 	name = "lonestar office jacket"
-	desc = "Stylish jacket lined for lonestar office workers. It seems have a little protection from physical harm."
+	desc = "Stylish jacket lined for lonestar office workers, padded for an inch of extra protection from harm."
 	icon_state = "cargoclerk_jacket"
 	item_state = "cargo_jacket"
 	blood_overlay_type = "coat"
@@ -99,7 +99,7 @@
 //Quartermaster
 /obj/item/clothing/suit/storage/rank/qm_coat
 	name = "surface manager coat"
-	desc = "An ideal choice for a smuggler. This coat seems have good impact resistance, and is made from resistant and expensive materials."
+	desc = "An ideal choice for the "businessman". This coat seems have good impact resistance, and is made from resistant and expensive materials."
 	icon_state = "qm_coat"
 	item_state = "qm_coat"
 	blood_overlay_type = "coat"
@@ -243,7 +243,7 @@
 
 /obj/item/clothing/suit/rank/chef/classic
 	name = "classic chef's apron"
-	desc = "A basic, dull, white chef's apron."
+	desc = "A basic and dull white chef's apron."
 	icon_state = "apronchef"
 	item_state = "apronchef"
 	blood_overlay_type = "armor"
@@ -252,7 +252,7 @@
 //Detective
 /obj/item/clothing/suit/storage/rank/insp_trench
 	name = "ranger's armored trenchcoat"
-	desc = "Brown and armored trenchcoat, designed and created by the Marshals. The coat is externally impact resistant - perfect for your next act of autodefenestration!"
+	desc = "Brown, armored trenchcoat. Designed and created by the Marshals. The coat is impact resistant - perfect for your next act of autodefenestration!"
 	icon_state = "rangercoat"
 	item_state = "rangercoat"
 	blood_overlay_type = "coat"

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -94,8 +94,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/under/rank/preacher
-	desc = "A dark ceremonial robe tailored for Primes."
-	name = "prime's robe"
+	desc = "A red ceremonial shirt tailored for Primes."
+	name = "prime's uniform"
 	icon_state = "preacher"
 	item_state = "w_suit"
 
@@ -225,13 +225,13 @@
 		return 1
 
 /obj/item/clothing/under/rank/chef
-	desc = "A pleasant yet practical suit for professional kitchen staff."
+	desc = "A comfy and practical suit for professional kitchen staff."
 	name = "chef's uniform"
 	icon_state = "chef"
 	item_state = "w_suit"
 
 /obj/item/clothing/under/rank/first_officer
-	desc = "A tan shirt with a Steward's badge, worn alongside some black leggings."
+	desc = "A tan shirt with a Steward's badge, worn alongside some black trousers."
 	name = "steward's uniform"
 	icon_state = "hop"
 	item_state = "b_suit"
@@ -305,6 +305,6 @@
 
 /obj/item/clothing/under/rank/lonestar_gorka
 	name = "lonestar gorka jumpsuit"
-	desc = "A gorka suit painted over with Lonestar orange and black."
+	desc = "An old gorka suit painted over with Lonestar orange and black."
 	icon_state = "ls_gorka"
 	item_state = "ls_gorka"

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -106,7 +106,7 @@
 
 /obj/item/clothing/under/rank/engineer/adv_master
 	desc = "A plastic-coated and iron-woven engineering suit worn by Guild Masters heading into dangerously radioactive areas for repair work. Offers full radiation protection."
-	name = "adept's padded emergency suit"
+	name = "Guild Master's padded emergency suit"
 	icon_state = "chiefengineeradv"
 	item_state = "chiefengineeradv"
 	armor_list = list(

--- a/code/modules/clothing/under/jobs/militia.dm
+++ b/code/modules/clothing/under/jobs/militia.dm
@@ -13,7 +13,7 @@
 
 /obj/item/clothing/under/rank/trooper/cadet
 	name = "green cadet uniform"
-	desc = "A rugged, baggy, one-size-fits-all set of militant and quite slavic two-tone clothes for volunteers, cadets, and conscripts."
+	desc = "An old, rugged, baggy, one-size-fits-all set of militant two-tone clothes for volunteers, cadets and conscripts."
 	icon_state = "gorka"
 	item_state = "gorka"
 
@@ -263,7 +263,7 @@
 
 /obj/item/clothing/under/rank/trooper/gorka
 	name = "blackshield gorka suit"
-	desc = "A rugged set of vaguely slavic two-tone overwear, made with robust materials and wearing the insignia of the Blackshield."
+	desc = "A rugged set of two-tone overwear, made with robust materials and the insignia of the Blackshield."
 	icon_state = "gorka_ih"
 
 /obj/item/clothing/under/rank/trooper/gorka/verb/toggle_style()
@@ -297,19 +297,19 @@
 
 /obj/item/clothing/under/rank/trooper/service
 	name = "blackshield service uniform"
-	desc = "A modern uniform with dark blue pants, with a white button up shirt. There are straps on the shoulders for adding shoulderboards."
+	desc = "A modern uniform with dark blue pants and white button up shirt. There are straps on the shoulders for adding shoulderboards."
 	icon_state = "trooper_service"
 	item_state = "trooper_service"
 
 /obj/item/clothing/suit/rank/trooper/service
 	name = "blackshield service jacket"
-	desc = "A modern dark blue uniform jacket. Fit for a trooper, even one on the frontier."
+	desc = "A modern dark blue service jacket to wear with the service uniform. Fit for a trooper, even one on the frontier."
 	icon_state = "trooper_service"
 	item_state = "trooper_service"
 
 /obj/item/clothing/suit/rank/trooper/dress
 	name = "blackshield dress jacket"
-	desc = "A modern dark blue uniform jacket. Fit for a trooper, even one on the frontier."
+	desc = "A modern dark blue dress jacket to wear with the service uniform for ceremonnial or offical occasions. Fit for a trooper, even one on the frontier."
 	icon_state = "trooper_dress"
 	item_state = "trooper_dress"
 
@@ -353,7 +353,7 @@
 
 /obj/item/clothing/under/rank/bdu/trooper
 	name = "Blackshield BDU"
-	desc = "A rugged militia Battle Dress Uniform, made with robust materials and wearing the insignia of the Blackshield."
+	desc = "A rugged militia Battle Dress Uniform, made with robust materials and the insignia of the Blackshield."
 	icon_state = "bdubsstandard"
 	item_state = "bdubsstandard"
 
@@ -394,7 +394,7 @@
 
 /obj/item/clothing/under/rank/armorer/gorka
 	name = "Sergeant's uniform"
-	desc = "A rugged set of vaguely slavic two-tone overwear, made with robust materials and wearing the pins of a Blackshield Sergeant."
+	desc = "A rugged set of two-tone overwear, made with robust materials and the pins of a Blackshield Sergeant."
 	icon_state = "gorka_ih"
 
 /obj/item/clothing/under/rank/armorer/gorka/verb/toggle_style()
@@ -433,19 +433,19 @@
 
 /obj/item/clothing/under/rank/armorer/service
 	name = "Blackshield NCO service uniform"
-	desc = "A modern uniform with silver trimmings on the dark blue pants, with a white button up shirt. There are straps on the shoulders for adding shoulderboards."
+	desc = "A modern uniform with silver trimmings on dark blue pants with a white button up shirt. There are straps on the shoulders for adding shoulderboards."
 	icon_state = "sergeant_service"
 	item_state = "sergeant_service"
 
 /obj/item/clothing/suit/rank/armorer/service
 	name = "Blackshield NCO service jacket"
-	desc = "A modern dark blue uniform jacket with silver trimmings. Fit for a mid-level trooper, even one on the frontier."
+	desc = "A modern dark blue service jacket with silver trimmings to wear with the service uniform. Fit for an enlisted leader, even one on the frontier."
 	icon_state = "sergeant_service"
 	item_state = "sergeant_service"
 
 /obj/item/clothing/suit/rank/armorer/dress
 	name = "Blackshield NCO dress jacket"
-	desc = "A modern dark blue uniform jacket with silver trimmings. Fit for a mid-level trooper, even one on the frontier."
+	desc = "A modern dark blue dress jacket with silver trimmings to wear with the service uniform for ceremonnial and official occasions. Fit for an enlisted leader, even one on the frontier."
 	icon_state = "sergeant_dress"
 	item_state = "sergeant_dress"
 
@@ -455,7 +455,7 @@
  */
 /obj/item/clothing/under/rank/commander
 	name = "commander's combat uniform"
-	desc = "It's a uniform worn by those few with the dedication to achieve the position of \"Blackshield Commander\". It has additional armor to protect the wearer."
+	desc = "Uniform worn by those few with the dedication to achieve the position of \"Blackshield Commander\". It has additional armor to protect the wearer."
 	icon_state = "gorka_ih"
 	siemens_coefficient = 0.8
 
@@ -489,7 +489,7 @@
 
 /obj/item/clothing/suit/rank/commander_service
 	name = "blackshield command service jacket"
-	desc = "A modern dark blue uniform jacket with gold trimmings. Fit for a command officer, even one on the frontier."
+	desc = "A modern dark blue uniform jacket with gold trimmings to go with the dress uniform for ceremonnial or official occasions. Fit for a field officer, even one on the frontier."
 	icon_state = "commander_service"
 	item_state = "commander_service"
 
@@ -522,19 +522,19 @@
 
 /obj/item/clothing/under/rank/brigservice
 	name = "blackshield general's service uniform"
-	desc = "A modern uniform with red trimmings on the dark blue pants, with a white button up shirt. There are straps on the shoulders for adding shoulderboards."
+	desc = "A modern uniform with red trimmings on dark blue pants with a white button up shirt. There are straps on the shoulders for adding shoulderboards."
 	icon_state = "brigadier_service"
 	item_state = "brigadier_service"
 
 /obj/item/clothing/suit/rank/brigservice
 	name = "blackshield general's service jacket"
-	desc = "A modern dark blue uniform jacket with red trimmings. Fit for a general officer, even one on the frontier."
+	desc = "A modern dark blue service jacket with red trimmings to wear with the service uniform. Fit for a general, even one on the frontier."
 	icon_state = "brigadier_service"
 	item_state = "brigadier_service"
 
 /obj/item/clothing/suit/rank/brigdress
 	name = "blackshield general's dress jacket"
-	desc = "A modern dark blue uniform jacket with red trimmings. Fit for a general officer, even one on the frontier."
+	desc = "A modern dark blue uniform jacket with red trimmings to wear with the dress uniform for ceremonnial or official occasions. Fit for a general, even one on the frontier."
 	icon_state = "brigadier_dress"
 	item_state = "brigadier_dress"
 

--- a/code/modules/clothing/under/jobs/militia.dm
+++ b/code/modules/clothing/under/jobs/militia.dm
@@ -353,7 +353,7 @@
 
 /obj/item/clothing/under/rank/bdu/trooper
 	name = "Blackshield BDU"
-	desc = "A rugged militia Battle Dress Uniform, made with robust materials and the insignia of the Blackshield."
+	desc = "A rugged militia Battle Dress Uniform, made with robust materials and adorned with Blackshield insignia."
 	icon_state = "bdubsstandard"
 	item_state = "bdubsstandard"
 

--- a/code/modules/clothing/under/jobs/militia.dm
+++ b/code/modules/clothing/under/jobs/militia.dm
@@ -263,7 +263,7 @@
 
 /obj/item/clothing/under/rank/trooper/gorka
 	name = "blackshield gorka suit"
-	desc = "A rugged set of two-tone overwear, made with robust materials and the insignia of the Blackshield."
+	desc = "A rugged set of two-tone overwear, made with robust materials and adorned with Blackshield insignia."
 	icon_state = "gorka_ih"
 
 /obj/item/clothing/under/rank/trooper/gorka/verb/toggle_style()


### PR DESCRIPTION
## About The Pull Request

Changes some job under and suit descriptions to have overall better syntax or descriptions.

## Changelog
Uniforms Changed:
Chef Uniform - pleasant changed to comfy
Preachers robe - dark changed to red, renamed to uniform (because it isnt dark, its red)
First Officer Uniform - changed leggings to trousers 

Suits Changed: 
Jackets of Assistants, Lonestar Cargo Tech - rephrased the part about protection to be more in line with the actual values)
SOM - renamed smuggler to "businessman"
Chef Apron - removed unnecessary commas
Rangers trenchcoat - rephrased for better readability
Gorkas for Jobs - removed slavic reference and replaced with "old"
Guild Masters padded emergency suit - renamed to "Guild Master's" since it had the same name as the one for the adept
Blackshield Descriptions - corrected and rephrased descriptions for gorkas and service/dress uniforms/jackets and adjusted the service clothing to reflect the respected rank. 
Changed Sergeant's "mid-level" for "enlisted leader", Commander's "command officer" to "field officer" and Brigadier's "general officer" to just "general".
