### PR TITLE
Slime-people changes

### DIFF
--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -671,17 +671,22 @@
 	icon_state = "hypermytosis"
 	var/cooldown = 5 MINUTES
 	passivePerk = FALSE
-	var/nutrition_cost = 450
+	var/nutrition_cost = 300
 
 /datum/perk/racial/limb_regen/activate()
 	if(world.time < cooldown_time)
 		to_chat(usr, SPAN_NOTICE("You've already regenerated recently, wait some time before trying again."))
 		return FALSE
+
 	if(holder.nutrition > nutrition_cost)
 		cooldown_time = world.time + cooldown
 		holder.nutrition -= nutrition_cost
 		to_chat(usr, SPAN_NOTICE("You turn your attention inward, focusing on mending your form."))
-		holder.reagents.add_reagent("mstim", 10)
+		var/mob/living/carbon/human/H = holder
+		for(var/name in BP_ALL_LIMBS)
+			if(!H.has_appendage(name))
+				H.restore_organ(name)
+
 	else
 		to_chat(usr, SPAN_NOTICE("You lack the energy for such an expenditure."))
 
@@ -714,6 +719,7 @@
 			holder.stats.addTempStat(STAT_TGH, amount_to_boost, duration, "Slime Biology")
 	else
 		to_chat(usr, SPAN_NOTICE("You lack the energy for such an expenditure."))
+
 /datum/perk/racial/slime_stat_boost/mental
 	name = "Malleable Mind"
 	desc = "Expend some of your spare calories to greatly improve your intellect."
@@ -746,33 +752,10 @@
 	holder.nutrition -= nutrition_cost
 	holder.reagents.add_reagent("slime_speed", 5)
 
-/* This is the old code for this perk, it does not work but it's left for postereity. Feel free to remove if you please - CDB
-/datum/perk/racial/limb_regen
-	name = "Gelatinous Regeneration"
-	desc = "Spend nutrition to regenerate lost limbs, albeit without fully fixing your injuries."
-	var/cooldown = 30 MINUTES
-	passivePerk = FALSE
-	var/nutrition_cost = 300
-
-/datum/perk/racial/limb_regen/activate()
-	if(world.time < cooldown_time)
-		to_chat(usr, SPAN_NOTICE("You can't regenerate again so soon!"))
-		return FALSE
-	cooldown_time = world.time + cooldown
-	holder.nutrition -= nutrition_cost
-	for(var/obj/item/organ/external/current_organ in holder.organs) //grab the current brute/burn of the limb, then re-apply half of it after rejuvenating OR subtract ten, whichever is lower
-		var/old_brute = current_organ.brute_dam
-		var/old_burn = current_organ.burn_dam
-		if(!(current_organ == BP_HEAD))
-			current_organ.replaced()
-		current_organ.rejuvenate()
-		current_organ.brute_dam = max(0, min((old_brute / 2), (old_brute - 10)))
-		current_organ.burn_dam = max(0, min((old_burn / 2), (old_burn - 10)))*/
-
 /datum/perk/racial/slime_metabolism
 	name = "Gelatinous Biology"
-	desc = "Your peculiar anatomy afford you a variety of benefits compared to most organics. Toxins will generally heal instead of hurt, whereas anti-toxins will hurt instead of heal.\
-	additionally you are somewhat resistant to NSA overload, and can slowly regenerate health so long as you have nutrition. "//This perk doesn't actually cause the slime-specific chem metabolism effects
+	desc = "Your peculiar anatomy afford you a variety of benefits compared to most organics. What causes toxin damage will heal it instead of causing it, and vice-versa.\
+	Additionally you are somewhat resistant to NSA overload, and can slowly regenerate health so long as you have nutrition."
 	icon_state = "gelatinousbiology"
 	passivePerk = TRUE
 	var/regen_rate = 0.3
@@ -784,14 +767,12 @@
 
 /datum/perk/racial/slime_metabolism/assign(mob/living/L)
 	..()
-	holder.toxin_mod_perk -= 0.5
 	if(ishuman(holder))
 		var/mob/living/carbon/human/H = holder
 		H.metabolism_effects.nsa_bonus += 100
 		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/racial/slime_metabolism/remove()
-	holder.toxin_mod_perk += 0.5
 	if(ishuman(holder))
 		var/mob/living/carbon/human/H = holder
 		H.metabolism_effects.nsa_bonus -= 100

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -109,7 +109,7 @@ var/global/list/image/splatter_cache=list()
 				S.add_overlay(S.blood_overlay)
 			S.blood_DNA |= blood_DNA.Copy()
 
-	else if (hasfeet)//Or feet
+	else if (hasfeet && perp.species.reagent_tag != IS_SLIME)//Or feet
 		perp.feet_blood_color = basecolor
 		perp.track_blood = max(amount,perp.track_blood)
 		shoe_types |= /obj/effect/decal/cleanable/blood/bearfoot

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -149,6 +149,9 @@
 			if(H.shoes)
 				return
 
+			if(H.species.reagent_tag == IS_SLIME)
+				return
+
 			to_chat(M, SPAN_DANGER("You step on \the [src]!"))
 
 			var/list/check = list(BP_L_LEG, BP_R_LEG)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1617,7 +1617,37 @@ var/list/rank_prefix = list(\
 
 /mob/living/carbon/human/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
 	. = ..()
-//no more slime cleaning
+	if(.)
+		if(species.reagent_tag == IS_SLIME && !shoes) // Slimes clean the floor. Code stolen from the roombas
+			var/turf/tile = loc
+			var/nutrition_gained = 1 // Up here for ease of modification
+			if(isturf(tile))
+				tile.clean_blood()
+				for(var/A in tile)
+					if(istype(A, /obj/effect))
+						if(istype(A, /obj/effect/decal/cleanable))
+							qdel(A)
+							src.nutrition += nutrition_gained // Gain some nutrition
+					else if(istype(A, /obj/item))
+						var/obj/item/cleaned_item = A
+						cleaned_item.clean_blood()
+					else if(ishuman(A))
+						var/mob/living/carbon/human/cleaned_human = A
+						if(cleaned_human.lying)
+							if(cleaned_human.head)
+								cleaned_human.head.clean_blood()
+								cleaned_human.update_inv_head(0)
+							if(cleaned_human.wear_suit)
+								cleaned_human.wear_suit.clean_blood()
+								cleaned_human.update_inv_wear_suit(0)
+							else if(cleaned_human.w_uniform)
+								cleaned_human.w_uniform.clean_blood()
+								cleaned_human.update_inv_w_uniform(0)
+							if(cleaned_human.shoes)
+								cleaned_human.shoes.clean_blood()
+								cleaned_human.update_inv_shoes(0)
+							cleaned_human.clean_blood(1)
+							to_chat(cleaned_human, SPAN_DANGER("[src] cleans your face!"))
 
 /mob/living/carbon/human/proc/set_remoteview(var/atom/A)
 	remoteview_target = A

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -42,8 +42,8 @@
 			var/obj/item/cruciform_upgrade/speed_of_the_chosen/sotc = upgrade
 			tally -= sotc.speed_increase
 
-	//If we are not a synth then we have some movement delays thanks to hunger
-	if(species.reagent_tag != IS_SYNTHETIC)
+	//If we are not a synth or a slime then we have some movement delays thanks to hunger
+	if(species.reagent_tag != IS_SYNTHETIC && species.reagent_tag != IS_SLIME)
 		var/health_deficiency = (maxHealth - health)
 		var/hunger_deficiency = (max_nutrition - nutrition)
 		var/hunger_half = max_nutrition * 0.5			//50% of max nutrition

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1119,8 +1119,8 @@
 	flags = NO_SLIP | NO_BREATHE | NO_BLOOD | NO_SCAN | NO_MINOR_CUT
 	siemens_coefficient = 3 //conductive
 	darksight = 3
-	always_blood = TRUE
-	always_ingest = TRUE
+	always_blood = FALSE
+	always_ingest = FALSE
 	breath_type = null
 	poison_type = null
 	hunger_factor = 2
@@ -1130,11 +1130,11 @@
 	injury_type =  INJURY_TYPE_HOMOGENOUS
 	taste_sensitivity = TASTE_SENSITIVE
 
-	nutrition_mod = 150 //Important for some perks
+	nutrition_mod = 250 //Important for some perks
 
 	burn_mod = 1.2
 	brute_mod = 1.2
-	toxins_mod = 1 // fuck toxins_mod, we use a perk for this
+	toxins_mod = -1 // What normally deals toxin damage instead heal toxin damage, and what normally heals toxin damage now deals toxin damage.
 	oxy_mod = 0
 
 	cold_discomfort_level = 283
@@ -1149,8 +1149,7 @@
 	heat_level_3 = 372 //Default 460
 
 	has_process = list(
-		BP_BRAIN = /obj/item/organ/internal/vital/brain/slime,
-		OP_STOMACH = /obj/item/organ/internal/stomach/slime
+		BP_BRAIN = /obj/item/organ/internal/vital/brain/slime
 		)
 
 	breath_type = null
@@ -1174,9 +1173,8 @@
 
 /datum/species/slime/get_bodytype()
 	return "Aulvae"
-/*
+
 /datum/species/slime/handle_death(var/mob/living/carbon/human/H)
-	spawn(1)
+	spawn()
 		if(H)
 			H.gib()
-*/

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -88,14 +88,8 @@
 		M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)
 		M.add_chemical_effect(CE_ANTITOX, 0.3 * effect_multiplier)
 		M.add_chemical_effect(CE_BLOODCLOT, 0.1)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 1 * effect_multiplier)
 	if(!ishuman(M))
 		M.adjustHalLoss(-0.5)
-
-/datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 2)
 
 /datum/reagent/water/extinguisher
 	name = "Extinguisher"
@@ -124,18 +118,6 @@
 	T.color = "white"
 	return TRUE
 
-/datum/reagent/water/extinguisher/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 1 * effect_multiplier)
-
-/datum/reagent/water/extinguisher/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
-	if(M.species?.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 1 * effect_multiplier)
-
-/datum/reagent/water/extinguisher/affect_blood(var/mob/living/carbon/M, var/alien)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 2)
-
 /datum/reagent/water/holywater
 	name = "Holy Water"
 	description = "A ubiquitous chemical substance that is composed of hydrogen and oxygen with the blessings of faith."
@@ -152,14 +134,6 @@
 		return
 	M.heal_organ_damage(0, 0.2 * effect_multiplier, 0, 3 * effect_multiplier)
 	..()
-
-/datum/reagent/water/holywater/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 1 * effect_multiplier)
-
-/datum/reagent/water/holywater/affect_blood(var/mob/living/carbon/M, var/alien)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 2)
 
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	..()
@@ -214,8 +188,6 @@
 		*/
 
 /datum/reagent/water/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 2)
 	if(isslime(M))
 		var/mob/living/carbon/slime/S = M
 		S.adjustToxLoss(20 * effect_multiplier) // Babies have 150 health, adults have 200; So, 10 units and 13.5

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -125,8 +125,6 @@
 	id = "holywater"
 
 /datum/reagent/water/holywater/affect_ingest(mob/living/carbon/human/M, alien, effect_multiplier)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 2)
 	var/obj/item/implant/core_implant/I = M.get_core_implant(/obj/item/implant/core_implant/cruciform)
 	if(!I && !I.wearer) //Do we have a core implant?
 		return

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -2009,17 +2009,9 @@
 
 /datum/reagent/ethanol/ntcahors/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	..()
-	if(M.species?.reagent_tag == IS_SLIME)
-		M.adjust_hallucination(-0.9 * effect_multiplier)
-		M.reagents.remove_reagent("wormwood", 0.8 * effect_multiplier) //well at least we still do these basic things.
-		M.take_organ_damage(1, 0) //we are however still bad for slime biology.
-		M.apply_damage(1, HALLOSS)
-		if(prob(5))
-			to_chat(M, "You feel a distinctive ache as something begins to eat away at you from the inside out!")
-	else
-		M.adjust_hallucination(-0.9 * effect_multiplier)
-		M.add_chemical_effect(CE_TOXIN, -2.5 * effect_multiplier)
-		M.reagents.remove_reagent("wormwood", 0.8 * effect_multiplier)
+	M.adjust_hallucination(-0.9 * effect_multiplier)
+	M.add_chemical_effect(CE_TOXIN, -2.5 * effect_multiplier)
+	M.reagents.remove_reagent("wormwood", 0.8 * effect_multiplier)
 
 // Cocktails
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -102,12 +102,8 @@
 	nerve_system_accumulations = 20
 
 /datum/reagent/medicine/varceptol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if((M.species?.reagent_tag == IS_SLIME))
-		M.take_organ_damage(1, 0)
-		M.apply_damage(1, HALLOSS)
-		if(prob(5)) // dont wanna do it constantly.
-			to_chat(M, "You feel a distinctive ache as something begins to eat away at you from the inside out!")
 	M.heal_organ_damage(9 * removed, 0)
+	M.add_chemical_effect(CE_ANTITOX, 3 * removed)
 
 /datum/reagent/medicine/meralyne
 	name = "Meralyne"
@@ -205,12 +201,6 @@
 	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/dylovene/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	if((M.species?.reagent_tag == IS_SLIME))
-		M.take_organ_damage(0.5, 0)
-		M.apply_damage(0.5, HALLOSS)
-		if(prob(5))
-			to_chat(M, "You feel a distinctive ache as something begins to eat away at you from the inside out!")
-		return
 	M.drowsyness = max(0, M.drowsyness - 0.6 * effect_multiplier)
 	M.adjust_hallucination(-0.9 * effect_multiplier)
 	M.add_chemical_effect(CE_ANTITOX, 2)
@@ -259,12 +249,6 @@
 	nerve_system_accumulations = -10
 
 /datum/reagent/medicine/carthatoline/affect_blood(var/mob/living/carbon/M, var/alien, effect_multiplier, var/removed = REM)
-	if(M.species?.reagent_tag == IS_SLIME)
-		M.take_organ_damage(2, 0)
-		M.apply_damage(2, HALLOSS)
-		if(prob(5))
-			to_chat(M, "You feel a distinctive ache as something begins to eat away at you from the inside out!")
-		return
 	M.add_chemical_effect(CE_ANTITOX, 3 * (dose * 0.1)) //every 10u is 3 antitox, starts out slow but rapidly grows
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -403,12 +387,6 @@
 
 /datum/reagent/medicine/tricordrazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
-		return
-	if(M.species?.reagent_tag == IS_SLIME)
-		M.take_organ_damage(1, 0)
-		M.apply_damage(1, HALLOSS)
-		if(prob(5))
-			to_chat(M, "You feel a distinctive ache as something begins to eat away at you from the inside out!")
 		return
 	M.adjustOxyLoss(-0.6 * effect_multiplier)
 	M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -25,27 +25,15 @@
 			var/mob/living/carbon/human/H = M
 			H.sanity.onToxin(src, effect_multiplier)
 			M.sanity.onToxin(src, multi)*/
-		if(M.species?.reagent_tag == IS_SLIME)
-			M.heal_organ_damage(0.1 * strength, 0.1 * strength)
-			M.add_chemical_effect(CE_ANTITOX, 0.3 * strength)
-		else
-			M.add_chemical_effect(CE_TOXIN, strength + dose / 2)
+		M.add_chemical_effect(CE_TOXIN, strength + dose / 2)
 
 /datum/reagent/toxin/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	if(strength)
-		if(M.species?.reagent_tag == IS_SLIME)
-			M.heal_organ_damage(0.1 * strength, 0.1 * strength)
-			M.add_chemical_effect(CE_ANTITOX, 0.3 * strength)
-		else
-			M.add_chemical_effect(CE_TOXIN, strength + dose / 3)
+		M.add_chemical_effect(CE_TOXIN, strength + dose / 3)
 
 /datum/reagent/toxin/overdose(mob/living/carbon/M, alien)
 	if(strength)
-		if(M.species?.reagent_tag == IS_SLIME)
-			M.heal_organ_damage(0.05 * strength, 0.05 * strength)
-			M.add_chemical_effect(CE_ANTITOX, 0.1)
-		else
-			M.add_chemical_effect(CE_TOXIN, strength * dose / 4)
+		M.add_chemical_effect(CE_TOXIN, strength * dose / 4)
 
 /datum/reagent/toxin/wormwood
 	name = "Wormwood"
@@ -176,8 +164,6 @@
 	if(strength)
 		if(M.species?.reagent_tag == IS_SLIME)
 			M.adjustNutrition(strength)
-			M.heal_organ_damage(0.2 * strength, 0.2 * strength)
-			M.add_chemical_effect(CE_ANTITOX, 0.3 * strength)
 			return
 		if(ishuman(M))
 			..()


### PR DESCRIPTION
## About The Pull Request
Changes a lot of stuff about the slime-people : 
- They gibs on death.
- They are revived by injecting plasma in their brain/core. Which works now.
- They no longer have a stomach. It's part of the Core now.
- Properly inversed the effect of toxin damage.
- The cost of regenerating limbs has been reduced to 300 nutrition, and no longer relies on chemicals.
- They now clean the floors when barefoot.
- They no longer get slown down by hunger. Very usefull when most of your perks consumes half of your hunger bar.
- Maximum nutrition increased to 650.
- Heart Organ Efficiency has been removed from bones. Because slimes don't have blood.
- Chemicals that heal toxin damage no longer causes organ damage.
- Water no longer hurt slime-people.
- Walking bare-foot on glass shards do not hurt them.
