### PR TITLE
Fixes and landmines idfk

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -1682,7 +1682,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "arE" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/structure/sink/basin,
+/obj/structure/sink/basion,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
 "arF" = (
@@ -20892,7 +20892,7 @@
 /area/nadezhda/outside/pond)
 "dXr" = (
 /obj/structure/table/rack/shelf,
-/obj/item/storage/rped/compact,
+/obj/item/storage/part_replacer/mini,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "dXv" = (
@@ -58613,7 +58613,10 @@
 "lcH" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mine/armed,
+/obj/item/mine/excelsior{
+	armed = 1;
+	anchored = 1
+	},
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lcI" = (
@@ -77181,8 +77184,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 2
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -82804,7 +82807,10 @@
 "pCq" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mine/armed,
+/obj/item/mine/excelsior{
+	armed = 1;
+	anchored = 1
+	},
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pCr" = (
@@ -98110,7 +98116,7 @@
 	})
 "suY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/sink/basin,
+/obj/structure/sink/basion,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "svb" = (
@@ -115206,7 +115212,10 @@
 /area/nadezhda/engineering/workshop)
 "vDi" = (
 /obj/machinery/door/airlock/maintenance_common,
-/obj/item/mine/armed,
+/obj/item/mine/excelsior{
+	armed = 1;
+	anchored = 1
+	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vDn" = (
@@ -124759,9 +124768,6 @@
 "xrO" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
-/obj/item/mine/excelsior{
-	armed = 1
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -1682,7 +1682,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "arE" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/structure/sink/basion,
+/obj/structure/sink/basin,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
 "arF" = (
@@ -20892,7 +20892,7 @@
 /area/nadezhda/outside/pond)
 "dXr" = (
 /obj/structure/table/rack/shelf,
-/obj/item/storage/part_replacer/mini,
+/obj/item/storage/rped/compact,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "dXv" = (
@@ -98116,7 +98116,7 @@
 	})
 "suY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/sink/basion,
+/obj/structure/sink/basin,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "svb" = (
@@ -124768,6 +124768,10 @@
 "xrO" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
+/obj/item/mine/excelsior{
+	armed = 1;
+	anchored = 1
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;


### PR DESCRIPTION
Changed the nondescript landmines in the Excelsior base to Excelsior branded landmines 

Fixed the busted disposals loop in xenobotany and the CRO's office
