### PR TITLE
Borer Soft Rework

### DIFF
--- a/code/datums/perks/backgrounds.dm
+++ b/code/datums/perks/backgrounds.dm
@@ -16,11 +16,13 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	name = "Lungs of Iron"
 	desc = "For whatever reason, be it natural evolution or simply spending too much time in space or low oxygen worlds your lungs are adapted to surviving with less oxygen."
 	icon_state = "lungs" // https://game-icons.net/1x1/lorc/one-eyed.html
+	copy_protected = TRUE
 
 /datum/perk/space_asshole
 	name = "Rough Life"
 	desc = "Your past life has been one of turmoil and extremes and as a result has toughened you up severely. Environmental damage from falling or explosives have less of an effect on your toughened body."
 	icon_state = "bomb" // https://game-icons.net
+	copy_protected = TRUE
 
 /datum/perk/space_asshole/assign(mob/living/L)
 	..()
@@ -45,6 +47,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	active = FALSE
 	passivePerk = FALSE
 	var/anti_cheat = FALSE
+	copy_protected = TRUE
 
 /datum/perk/linguist/activate()
 	..()
@@ -79,6 +82,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	desc = "Life as a Void Wolf has given you amazing agility. You can climb railings, walls, and ladders much faster than others. In addition you can dodge, combat roll, and stand up from prone much \
 	faster. Finally, your rough and tumble movement makes falling from high heights deal a lot less damage compared to others and you will always land on your feet."
 	icon_state = "parkour" //https://game-icons.net/1x1/delapouite/jump-across.html
+	copy_protected = TRUE
 
 /datum/perk/parkour/assign(mob/living/L)
 	..()
@@ -94,18 +98,20 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	name = "Unclean Living"
 	desc = "The bad conditions of your upbringing have led you to thrive in toxic environments, so much so that your body is dependent on having an unclean atmosphere. You feel tougher and slowly heal toxin damage when smoking."
 	icon_state = "cigarette" // https://game-icons.net
+	copy_protected = TRUE
 
 /datum/perk/blood_of_lead
 	name = "Lead Blood"
 	desc = "Maybe you grew up on a world with a toxic atmosphere, maybe solar radiation was common, or maybe its just genetics but you're adapted well to dealing with toxins."
 	icon_state = "liver" // https://game-icons.net
+	copy_protected = TRUE
 
 /datum/perk/greenthumb
 	name = "Green Thumb"
 	desc = "After growing plants for years (or at least being around those who do) you have become a botanical expert. You can get all information about plants, from stats \
 	        to harvest reagents, by examining them."
 	icon_state = "greenthumb" // https://game-icons.net/1x1/delapouite/farmer.html
-
+	//Same reasoning as other perks such as medical. Copy protect if it ends up being too strong.
 	var/virtual_scanner = new /obj/item/device/scanner/plant/perk
 
 /datum/perk/greenthumb/assign(mob/living/L)
@@ -119,6 +125,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 			This increases chance of positive breakdowns by 30% and negative breakdowns by 20%. Seeing someone die has a random effect on you: \
 			sometimes you won’t take any sanity loss and you can even gain back sanity, or get a boost to your cognition."
 	icon_state = "eye" //https://game-icons.net/1x1/lorc/tear-tracks.html
+	copy_protected = TRUE
 
 /datum/perk/nihilist/assign(mob/living/L)
 	if(..() && ishuman(L))
@@ -141,12 +148,14 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 			But it is not this day. This day you fight! \
 			Your Insight gain is faster when you are around sane people and they will recover sanity when around you. \
 			When you are around people that are low on health or sanity, you will take sanity damage."
+	copy_protected = TRUE
 
 /datum/perk/noble
 	name = "Wealthy Upbringing"
 	icon_state = "family" //https://game-icons.net
 	desc = "You came from a wealthy family of high stature, able to achieve a high education and spent most of your life capable of relaxing. \
 			Start with an heirloom weapon, higher chance to be on contractor contracts and removed sanity cap. Stay clear of filth and danger."
+	copy_protected = TRUE
 
 /datum/perk/noble/assign(mob/living/carbon/human/H)
 	if(!..() || !istype(H))
@@ -203,6 +212,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	desc = "You've been an addict all your life, for whatever piss poor reason you've told yourself. Your body is able to handle a variety of drugs, more than the average person, but you get \
 	easily addicted to all of them."
 	icon_state = "chemaddict" // https://game-icons.net/1x1/lorc/overdose.html
+	copy_protected = TRUE
 
 /datum/perk/addict/assign(mob/living/L)
 	..()
@@ -226,6 +236,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	This is in addition to knowing exactly how likely you were to fail after failing some tasks. \
 	This ability does not extend to medical matters, wounds or similar. "
 	icon_state = "obfuscation_ranking"
+	copy_protected = TRUE
 
 /datum/perk/blood_lust
 	name = "Bloodlust Aura"
@@ -234,6 +245,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	icon_state = "blood_lust"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/blood_lust/assign(mob/living/L)
 	if(..())
@@ -265,6 +277,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	desc = "Due to your intense training and upbringing you already know how to use the sheath arts, as well as how to handle the mind. \
 	All melee weapons that attack at range have a little bit extra reach when you wield them."
 	icon_state = "paintbrush"
+	copy_protected = TRUE
 
 /datum/perk/natural_style/assign(mob/living/L)
 	if(..() && ishuman(L))
@@ -287,6 +300,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/map_maker/activate()
 	var/mob/living/carbon/human/user = usr
@@ -430,6 +444,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	active = FALSE
 	passivePerk = FALSE
 	var/anti_cheat = FALSE
+	copy_protected = TRUE
 
 /datum/perk/linguist_fbp/activate()
 	..()

--- a/code/datums/perks/cooldown.dm
+++ b/code/datums/perks/cooldown.dm
@@ -1,6 +1,7 @@
 /datum/perk/cooldown
 	var/perk_lifetime = 5 MINUTES
 	var/timestamp_start
+	copy_protected = TRUE
 	gain_text = "You feel tired. Your body needs some time to recover from all this training."
 	lose_text = "You feel a bit more rested from the training."
 

--- a/code/datums/perks/imprinter_perks.dm
+++ b/code/datums/perks/imprinter_perks.dm
@@ -14,12 +14,14 @@ Chemical Neutralizer - Reduces addiction chance all the way down to 0.1 and incr
 	desc = "You are augmented with a Smartlink (in some places refered to as Smartgun) making you one with your weapons, allowing you to way better monitor and manage your recoil than a living being normally could."
 	gain_text = "You feel as if you were part of your weapon."
 	lose_text = "You can no longer feel inner workings of your weapon."
+	copy_protected = TRUE
 
 /datum/perk/cognitive_enhancer //Big brain time / To those concerned about nanogate, Mar'qua inspiration rounds to 1.65, Nanogate users get 0.03 to 0.33
 	name = "Cognitive Enhancer Augment"
 	desc = "You are augmented with a Cognitive Enchancer making you essentially have a second brain. While nowhere near as powerful as the real thing, it does alleviate a lot of strain on your actual brain allowing you to process information faster."
 	gain_text = "Your head feels lighter as if huge burden was carried away."
 	lose_text = "Your head starts feeling like a boulder again."
+	copy_protected = TRUE
 
 /datum/perk/cognitive_enhancer/assign(mob/living/L)
 	..()
@@ -34,6 +36,7 @@ Chemical Neutralizer - Reduces addiction chance all the way down to 0.1 and incr
 	desc = "You are augmented with a Chemical Neutralizer, a device capable of correcting chemical imbalance in brain and mandate inhibitor production outright negating almost all side effects of most drugs on the market."
 	gain_text = "You feel unnatural calmness."
 	lose_text = "Your start to crave after things again."
+	copy_protected = TRUE
 
 /datum/perk/chemical_neutralizer/assign(mob/living/L)
 	..()

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -29,6 +29,7 @@
 	var/old_max_insight = INFINITY
 	var/old_max_resting = INFINITY
 	var/old_insight_rest_gain_multiplier = 1
+	copy_protected = TRUE
 
 /datum/perk/job/artist/assign(mob/living/L)
 	..()
@@ -60,6 +61,7 @@
 	icon_state = "adrenalineburst_tim"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/timeismoney/activate()
 	var/mob/living/carbon/human/user = usr
@@ -84,6 +86,7 @@
 	desc = "Clean living in the Sol system has prevented you from building up a tolerance to most chemicals, your body can't handle the more hardcore drugs that most can and you find yourself getting \
 	addicted slightly easier."
 	icon_state = "solborn" // https://game-icons.net/1x1/lorc/overdose.html
+	copy_protected = TRUE //Origin Traits.
 
 /datum/perk/solborn/assign(mob/living/L)
 	..()
@@ -105,6 +108,7 @@
 	name = "Klutz"
 	desc = "You find a lot of tasks a little beyond your ability to perform such is using any type of weaponry, but being accident prone has at least made you used to getting hurt."
 	icon_state = "klutz"
+	copy_protected = TRUE //Blacklisted for the same reason Rez sickness is.
 
 /datum/perk/klutz/assign(mob/living/L)
 	..()
@@ -120,7 +124,7 @@
 	icon_state = "truefaith"
 	gain_text = "You feel the protection of the nearby obelisk."
 	lose_text = "You no longer feel the protection of an obelisk."
-
+	copy_protected = TRUE
 
 /datum/perk/active_sanityboost/assign(mob/living/L)
 	if(..() && ishuman(holder))
@@ -137,17 +141,19 @@
 	name = "Lazarus Protocol"
 	desc = "Your cruciform is more than just a symbol of faith. Should you ever perish, it will attempt an emergency revival that may restore your body after a short time, in which you'll be unconscious."
 	icon_state = "regrowth" // https://game-icons.net/1x1/delapouite/stump-regrowth.html
+	copy_protected = TRUE
 
 /datum/perk/community_of_saints
 	name = "Community of the Saints"
 	desc = "Your cruciform connects you to all other believers, but such connection can be distracting as well as beneficial. You take 25% longer to complete all tool-based actions that aren't instantaneous."
 	icon_state = "communityofthesaints"
+	copy_protected = TRUE
 
 /datum/perk/ear_of_quicksilver
 	name = "Ear of Quicksilver"
 	desc = "Training (and an ear implant) given to you as a Ranger makes it hard for secrets to escape your ears. Beware, loud noises are especially dangerous to you as a side effect."
 	icon_state = "ear" // https://game-icons.net
-
+	copy_protected = TRUE
 
 /datum/perk/chemist
 	name = "Periodic Table"
@@ -193,6 +199,7 @@
 /datum/perk/scribe
 	name = "Scribe"
 	desc = "Your ability to turn experiences into words knows no bounds. Paper at this point is hardly able to hold the power of your writing."
+	copy_protected = TRUE
 
 /datum/perk/scribe/assign(mob/living/L)
 	..()
@@ -209,6 +216,7 @@
 	perk_lifetime = 3 SECONDS
 	gain_text = "The scroll's smoke fills your eyes. Whats moving in the walls?"
 	lose_text = "Your eyes sting but you don't see the pain anymore."
+	copy_protected = TRUE
 
 /datum/perk/cooldown/reveal/assign(mob/living/L)
 	..()
@@ -297,6 +305,7 @@
 	gain_text = "Your body aches from the pain of returning from death, you better find a chair or bed to rest in so you can heal properly."
 	lose_text = "You finally feel like you recovered from the ravages of your body."
 	var/initial_time
+	copy_protected = TRUE //no griefing people, naughty borer/carrion
 
 /datum/perk/rezsickness/assign(mob/living/L)
 	..()
@@ -409,6 +418,7 @@
 	lose_text = "The thunder bouncing around just beneath your dermis has passed and you feel stable once again."
 	var/initial_time
 	icon_state = "slime_rez"
+	copy_protected = TRUE
 
 /datum/perk/racial/slime_rez_sickness/assign(mob/living/L)
 	..()
@@ -442,6 +452,7 @@
 	name = "Handyman"
 	desc = "Training by the Artificer's Guild has granted you the knowledge of how to take apart machines in the most efficient way possible, finding materials and supplies most people would miss. This training is taken further the more mechanically skilled or cognitively capable you are."
 	icon_state = "handyman"
+	copy_protected = TRUE
 
 /datum/perk/handyman/assign(mob/living/L)
 	..()
@@ -454,13 +465,15 @@
 	name = "Anomaly Hunter"
 	desc = "Special training from senior Prospectors and your own experience has allowed you to instinctively know the effects of greater oddities. By examining an oddity that has become an anomaly, you can tell what its greater boon or curse may be."
 	icon_state = "anomalyhunter"
+	copy_protected = TRUE //This isn't like market professional. Too strong to be able to copy.
 
 /datum/perk/market_prof
 	name = "Market Professional"
 	desc = "You've become an excellent appraiser of goods over the years. Just by looking at the item, you can know how much it would sell for in today's market rates."
 	icon_state = "marketprofessional"
+	//The only reason this isn't copy protected is it doesn't lock unique recipies and isn't gamebreaking.
 
-//Medical perks - relates to surgery and all.
+//Medical perks - relates to surgery and all - If this ends up being too OP, copy protect all of them.
 
 /datum/perk/surgical_master
 	name = "Surgery Training"
@@ -492,11 +505,13 @@
 	name = "Key Smith"
 	desc = "You have been granted a multitude of specially crafted electronic 'keys' for opening most airlocks around the colony, and the knowledge on how to use them has been solely been passed on to you. Don't get discouraged, you will eventually find the right one..."
 	icon_state = "keysmith"
+	copy_protected = TRUE //No.
 
 /datum/perk/job/blackshield_conditioning
 	name = "Blackshield Conditioning"
 	desc = "Thanks to special and intensive training received in the course of your employment with Blackshield, with all the practice gained in space you feel you can jump from greater heights and know when to duck-and-cover."
 	icon_state = "blackshieldconditioning"
+	copy_protected = TRUE //Physical trait. Not mental.
 
 /datum/perk/job/blackshield_conditioning/assign(mob/living/L)
 	..()
@@ -513,6 +528,7 @@
 	desc = "You've been through it all. Spider bites, random cuts on rusted metal, animal claws, getting shot, and even set on fire. Hell, even a few used needles in desperate times. You feel as though your body fights off the inflictions of too much NSA and addictions much better than others."
 	icon_state = "roughandtumble"
 	perk_shared_ability = PERK_SHARED_SEE_ILLEGAL_REAGENTS
+	copy_protected = TRUE
 
 /datum/perk/job/prospector_conditioning/assign(mob/living/L)
 	..()
@@ -553,6 +569,7 @@
 	name = "SI Science Training"
 	icon_state = "sitraining"
 	desc = "You know how to use RnD core consoles and Exosuit Fabs."
+	copy_protected = TRUE //No.
 
 /datum/perk/neat
 	name = "Humble Cleanser"
@@ -560,6 +577,7 @@
 			This perk reduces the total sanity damage you can take from what is happening around you. \
 			You can regain sanity by cleaning."
 	icon_state = "neat" // https://game-icons.net/1x1/delapouite/broom.html
+	copy_protected = TRUE //No.
 
 /datum/perk/neat/assign(mob/living/L)
 	if(..() && ishuman(holder))
@@ -577,12 +595,13 @@
 	desc = "You know how to channel spiritual energy during rituals. You gain additional skill points \
 			during group rituals, and have an increased regeneration of cruciform energy."
 	icon_state = "channeling"
-
+	copy_protected = TRUE
 
 /datum/perk/codespeak
 	name = "Codespeak"
 	desc = "You know Marshal codes."
 	icon_state = "codespeak" // https://game-icons.net/1x1/delapouite/police-officer-head.html
+	copy_protected = TRUE //Borers already grant omni language translation.
 	var/list/codespeak_procs = list(
 		/mob/living/carbon/human/proc/codespeak_help,
 		/mob/living/carbon/human/proc/codespeak_clear,
@@ -640,6 +659,7 @@
 	active = FALSE
 	passivePerk = FALSE
 	icon_state = "spice"
+	copy_protected = TRUE //Chefs are already under-played. No reason to destroy the role further.
 
 /datum/perk/foodappraise/activate()
 	var/mob/living/carbon/human/user = usr
@@ -692,6 +712,7 @@
 	passivePerk = FALSE
 	var/anti_cheat = FALSE
 	icon_state = "true_name"
+	copy_protected = TRUE
 
 /datum/perk/true_name/activate()
 	..()

--- a/code/datums/perks/nanite_powers.dm
+++ b/code/datums/perks/nanite_powers.dm
@@ -8,6 +8,7 @@
 	var/emped_end_message = null	//Message displayed when EMP effect ends
 	var/emped = FALSE				//Whether we are currently being affected by an EMP
 	var/emp_duration = 0			//Duration of EMP effects
+	copy_protected = TRUE //Yeah. No.
 
 /datum/perk/nanite_power/assign(mob/living/L)
 	. = ..()

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -8,6 +8,7 @@
 	icon_state = "nanogateimplant"
 	gain_text = "Your head aches for a moment, the effects of your spine having been seperated and an advanced machine slotted inbetween leaving you with a dull pain that is quickly cured \
 	by your nanites."
+	copy_protected = TRUE
 
 /datum/perk/nanite_power/nanite_regen
 	name = "Nanite Regeneration"

--- a/code/datums/perks/nepotism.dm
+++ b/code/datums/perks/nepotism.dm
@@ -3,18 +3,21 @@
 	desc = "You earn about 30% higher pay than your fellow peers- The spirit of capitalism smiles upon you."
 	icon_state = "nepotism"
 	gain_text = "You feel comforted, knowing the amount of money coming your way."
+	copy_protected = TRUE
 
 /datum/perk/debtor
 	name = "Debtor"
 	desc = "You owe money to someone or something. Unfortunately, your wages have been garnished to make up the difference."
 	icon_state = "debtor"
 	gain_text = "You feel annoyed, thinking about how much of your wage is going into paying off your debt."
+	copy_protected = TRUE
 
 /datum/perk/splicer
 	name = "Splicer"
 	desc = "Your genes are heavily modified already, your base genetic instability is 20%, even if you don't have any mutations."
 	icon_state = "splicer"
 	gain_text = "Your body is modified enough already; pushing it further might be bad."
+	copy_protected = TRUE
 
 //Genetics is made reliably enough that simply increasing total instability, a dynamically changing value, will be permanent until removed.
 /datum/perk/splicer/assign(mob/living/L)

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -1,5 +1,6 @@
 /datum/perk/oddity
 	gain_text = "You feel different. Exposure to oddities has changed you. Now you can't go back."
+	copy_protected = TRUE //ALL Oddity perks blacklisted by default. Unblacklist individual ones.
 
 /datum/perk/oddity/survivor
 	name = "Survivor"
@@ -80,18 +81,21 @@
 	desc = "The latent effects of an oddity have granted you an insight into firing bullets faster than anyone else; a shame it doesn't make you immune to recoil."
 	gain_text = "Your trigger finger feels more relaxed than ever..."
 	icon_state = "dual_shot" // https://game-icons.net/1x1/delapouite/bullet-impacts.html
+	copy_protected = FALSE
 
 /datum/perk/oddity/balls_of_plasteel
 	name = "True Grit"
 	desc = "Pain comes and goes, you feel as though can withstand far worse than ever before."
 	gain_text = "Pain is merely weakness leaving the body."
 	icon_state = "golem" // https://game-icons.net
+	copy_protected = FALSE
 
 /datum/perk/oddity/fast_walker
 	name = "Springheel"
 	desc = "You're sure of your movements now, slow and steady may win the race but you can prove them wrong."
 	gain_text = "You feel your pace quickening, your thoughts barely catching up with your stride..."
 	icon_state = "fast" // https://game-icons.net/1x1/delapouite/fast-forward-button.html
+	//Unblacklist if you feel like it. For obvious reasons, Borers would LOVE to copy this to every host.
 
 /datum/perk/oddity/fast_walker/assign(mob/living/L)
 	..()
@@ -103,6 +107,7 @@
 	desc = "Your skin has become harder, more durable, able to accept blunt force and endure."
 	gain_text = "After all you've endured, you can't help but feel tougher than normal, your skin feels like iron."
 	icon_state = "riotshield"
+	copy_protected = FALSE
 
 /datum/perk/oddity/harden/assign(mob/living/L)
 	..()
@@ -143,6 +148,7 @@
 	desc = "You've been exposed to something toxic, yet your body fought it off and is now strengthened against poisoning as a result."
 	gain_text = "What doesn't kill you, helps you survive it better."
 	icon_state = "alch"
+	copy_protected = FALSE
 
 /datum/perk/oddity/better_toxins/assign(mob/living/L)
 	..()
@@ -225,6 +231,7 @@
 	desc = "You're more keenly aware of your own abilities for combat. You feel more confident on your punches thrown, a bit tougher against those thrown at you, and you're starting to get the hang of shooting that one bulky gun..."
 	gain_text = "The blood pumps, the muscles harden, and your trigger finger feels easier than ever..."
 	icon_state = "muscular"
+	copy_protected = FALSE
 
 /datum/perk/oddity/strangth/assign(mob/living/L)
 	..()
@@ -242,6 +249,7 @@
 	name = "Will of Iron"
 	desc = "The body is able to succumb to many negative affects but the mind can simply ignore them. Getting addicted to things is much harder and you can stomach more chemicals."
 	icon_state = "ironpill" // https://game-icons.net/1x1/lorc/underdose.html
+	copy_protected = FALSE
 
 /datum/perk/oddity/iron_will/assign(mob/living/L)
 	..()
@@ -263,6 +271,7 @@
 	name = "Will to Power"
 	desc = "The mind protects the body by imposing limits to prevent severe harm to the self. With enough focus, you can push yourself past that limit."
 	icon_state = "ironpill" // https://game-icons.net/1x1/lorc/underdose.html
+	copy_protected = FALSE
 
 /datum/perk/oddity/mind_of_matter/assign(mob/living/L)
 	..()
@@ -281,6 +290,7 @@
 	gain_text = "Reloading with a simple mind is almost second nature..."
 	lose_text = "The reloading from the side is more complicated..."
 	icon_state = "plus_one" // https://game-icons.net/1x1/lorc/gears.html
+	copy_protected = FALSE
 
 /datum/perk/oddity/side_loading/assign(mob/living/L)
 	..()
@@ -336,6 +346,7 @@
 
 /datum/perk/nt_oddity
 	gain_text = "The Absolute chose you to expand its will."
+	copy_protected = TRUE //For obvious reasons.
 
 /datum/perk/nt_oddity/holy_light
 	name = "Holy Light"
@@ -372,6 +383,7 @@
 	lose_text = "The death heat of the universe strays further away... for now."
 	icon_state = "vortex"
 	var/initial_time
+	copy_protected = TRUE //Hm yes how about I crash bluespace again
 
 /datum/perk/bluespace/assign(mob/living/L)
 	..()
@@ -408,6 +420,7 @@
 	desc = "It's sleek contours, the expert craftsmanship... The best of hand-made mechanical genius."
 	gain_text = "What wondrous possibilities..."
 	icon_state = "tinker"
+	copy_protected = TRUE
 
 /datum/perk/guild/blackbox_insight/assign(mob/living/L)
 	..()
@@ -429,12 +442,13 @@
 /datum/perk/drug/ultrasurgeon
 	name = "Ultrasurgeon Knowledge"
 	desc = "After your fix of ultrasurgeon you can feel your mind ease just as your muscles relax."
+	copy_protected = TRUE
 
 /datum/perk/njoy
 	name = "Njoy (Active)"
 	desc = "Your mind can focus on what is real, just like when you get rid of a painful earring."
 	icon_state = "cheerful"  //https://game-icons.net/1x1/lorc/cheerful.html
-
+	copy_protected = TRUE
 	gain_text = "Your mind feels much clearer now."
 	lose_text = "You feel the shadows once more."
 

--- a/code/datums/perks/perk.dm
+++ b/code/datums/perks/perk.dm
@@ -38,6 +38,7 @@
 	// var/datum/action/innate/perk/perk_action
 	var/cooldown_time = 0
 	var/perk_shared_ability
+	var/copy_protected = FALSE //Handles being able to potentially copy PERKS between hosts for Borers and Carrions. Currenly unused.
 
 /datum/perk/New()
 	..()
@@ -70,8 +71,8 @@
 
 /// Proc called when the perk is assigned to a being. Should be the first thing to be called.
 /datum/perk/proc/assign(mob/living/L)
+	SHOULD_CALL_PARENT(TRUE)
 	if(istype(L))
-		SHOULD_CALL_PARENT(TRUE)
 		holder = L
 		RegisterSignal(holder, COMSIG_MOB_LIFE, PROC_REF(on_process))
 		to_chat(holder, SPAN_NOTICE("[gain_text]"))

--- a/code/datums/perks/psionic.dm
+++ b/code/datums/perks/psionic.dm
@@ -5,6 +5,7 @@
 	purity of body, any implants, cruciforms, or synthetics will be violently rejected as long as your psionic organ is in your head."
 	gain_text = "You suddenly get a splitting headache before your vision blurs painfully. By the time its over, you feel like a whole new world of possibilities has opened for you."
 	icon_state = "psionic"
+	copy_protected = TRUE
 
 /datum/perk/psion/assign(mob/living/L)
 	..()
@@ -21,12 +22,14 @@
 	desc = "You lived a life of unsettled violence. Maybe it was circumstance, maybe it was necessity, or maybe you just liked hurting people. No matter the reason, your mind is attuned to bloody \
 	violence and your potential as a psion reflects that. No matter your stats or physical body, you always deal maximum damage when using scaling psionic weaponry you create."
 	icon_state = "psionicpsychosis"
+	copy_protected = TRUE
 
 /datum/perk/psi_harmony
 	name = "Psionic Harmony"
 	desc = "You have achieved inner harmony, your balance of emotion giving you peace of mind and thus expanding your potential as a psion. With this frame of mind, you retain a \
 	higher maximum psi pool than others, increasing your capacity by two."
 	icon_state = "psionicharmony"
+	copy_protected = TRUE
 
 /datum/perk/psi_attunement
 	name = "Psionic Attunement"
@@ -34,18 +37,21 @@
 	use a psionic power that has a negative side effects, you take only half the penalties a psion normally would. Equally, some lesser powers like telepathic projection and telekinetic prowess \
 	no longer cost essence to use."
 	icon_state = "psionicattunement"
+	copy_protected = TRUE
 
 /datum/perk/psi_psychology
 	name = "Mind Master"
 	desc = "Your training as a Soteria psychologist and understanding of psychiatry has given you a deep understanding of how the mind works. As a result, if you became a psion, you have an \
 	expanded set of powers that aid you in your work, with additional essence to use your abilities."
 	icon_state = "mindmaster"
+	copy_protected = TRUE
 
 /datum/perk/psi_grace
 	name = "Psionic Grace"
 	desc = "The latent effects of a fellow psion with mastery over the mind has enhanced your abilities. The gifted enhancement allows you to recover your psi essence twice as fast."
 	gain_text = "You feel completely at peace for a moment, the workings of mind, body, and the space beyond suddenly becomes but a play thing for your mind. The feeling is fleeting, but the effects \
 	are lasting."
+	copy_protected = TRUE
 
 /datum/perk/psi_peace_of_the_psion
 	name = "Mind over Matter"
@@ -53,6 +59,7 @@
 	beyond any potential they once had."
 	gain_text = "Everything falls into place, all things become clear. You feel stronger, more alert, quicker. You have not attained perfection but you feel you are closer than ever before \
 	and the last mental block you had has been removed, the flood gates of success filling your mind."
+	copy_protected = TRUE
 
 /datum/perk/psi_peace_of_the_psion/assign(mob/living/L)
 	..()

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -48,6 +48,7 @@
 	icon_state = "suddenbrilliance"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/suddenbrilliance/activate()
 	var/mob/living/carbon/human/user = usr
@@ -66,11 +67,13 @@
 	name = "Inspired Intellect"
 	desc = "Even the most humble Mar'qua is capable of study and extrapolation, your natural intellect allows you to become gain inspiration more easily."
 	icon_state = "inspiredintellect"
+	copy_protected = TRUE
 
 /datum/perk/alien_nerves
 	name = "Adapted Nervous System"
 	desc = "A mar'qua's nervous system has long since adapted to the use of stimulants, chemicals, and different toxins. Unlike lesser races, you can handle a wide variety of chemicals before showing any side effects and you'll never become addicted."
 	icon_state = "adaptednervoussystem"
+	copy_protected = TRUE
 
 /datum/perk/alien_nerves/assign(mob/living/L)
 	..()
@@ -95,6 +98,7 @@
 	icon_state = "willtosurvive"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/iwillsurvive/activate()
 	var/mob/living/carbon/human/user = usr
@@ -115,6 +119,7 @@
 	icon_state = "inspiringbattlecry"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE //It would be extremely funny but I don't think we want the entire colony to be able to buff themselves infinitely
 
 /datum/perk/battlecry/activate()
 	var/mob/living/carbon/human/user = usr
@@ -152,6 +157,7 @@
 	name = "Tenacity"
 	desc = "Humans were always resilient, not letting anything or anyone to get in way of their goals. Due to this your body is way more adapted to anything thrown it's way letting you push onward for just a little bit longer than others."
 	icon_state = "tenacity"
+	copy_protected = TRUE
 
 /datum/perk/linguist_for_humans
 	name = "Diverse Culture"
@@ -160,6 +166,7 @@
 	active = FALSE
 	passivePerk = FALSE
 	var/anti_cheat = FALSE
+	copy_protected = TRUE
 
 /datum/perk/linguist_for_humans/activate()
 	..()
@@ -196,6 +203,7 @@
 	icon_state = "enhancesenses"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/enhancedsenses/activate()
 	var/mob/living/carbon/human/user = usr
@@ -214,6 +222,7 @@
 	name = "Instinctual Skill"
 	desc = "All kriosans understand the dynamics of shooting, to such a degree that guns are more extensions to one's hand than weapon. You take no penalty when firing any range weapon one handed."
 	icon_state = "instinctualskill"
+	copy_protected = TRUE
 
 ////////////////////////////////////////Akula perks
 /datum/perk/recklessfrenzy
@@ -223,6 +232,7 @@
 	icon_state = "recklessfrenzy"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/recklessfrenzy/activate()
 	var/mob/living/carbon/human/user = usr
@@ -242,7 +252,7 @@
 	name = "Iron Flesh"
 	desc = "Akula scales are not only tough and resistant to damage but exceptionally skilled at naturally forcing out embedded objects that somehow punch through. You'll never get a bullet nor object stuck inside when hit."
 	icon_state = "ironflesh"
-
+	copy_protected = TRUE
 
 ////////////////////////////////////////Naramad perks
 /datum/perk/adrenalineburst
@@ -251,6 +261,7 @@
 	icon_state = "adrenalineburst"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/adrenalineburst/activate()
 	var/mob/living/carbon/human/user = usr
@@ -270,11 +281,13 @@
 	name = "Hydration Reliance"
 	desc = "Naramad have adapted biology heavily reliant on the intake of fluids, in particular clean clear water. Drinking purified water, even tap water, heals your body slowly, as if you drank tricordizine!"
 	icon_state = "hydrationreliance"
+	copy_protected = TRUE
 
 /datum/perk/born_warrior
 	name = "Born Warrior"
 	desc = "No matter their background all naramadi are capable bringing any object to bear as a weapon, be it bladed or blunt. Unlike other races your grip is iron and you'll never lose your weapon through embedding it in an enemy."
 	icon_state = "bornwarrior"
+	copy_protected = TRUE
 
 /////////////////////////////////////////Cindarite perks
 /datum/perk/purgetoxins
@@ -283,6 +296,7 @@
 	icon_state = "purgetoxins"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/purgetoxins/activate()
 	var/mob/living/carbon/human/user = usr
@@ -303,6 +317,7 @@
 	icon_state = "uncannyresiliance"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/purgeinfections/activate()
 	var/mob/living/carbon/human/user = usr
@@ -321,6 +336,7 @@
 	name = "Second Skin"
 	desc = "Cindarites, be they bunker born or spacers, are used to wearing bulky enviromental suits. This life time of being acclimated to heavy clothing has become a second skin for many, allowing you to remove clothing instantly and never suffer slowdown from heavy armor."
 	icon_state = "secondskin"
+	copy_protected = TRUE
 
 ///////////////////////////////////////////Opifex perks
 /datum/perk/opifex_backup
@@ -329,6 +345,7 @@
 	icon_state = "smuggledtools"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/opifex_backup/activate()
 	var/mob/living/carbon/human/user = usr
@@ -350,7 +367,7 @@
 	icon_state = "smuggledmedicine"
 	active = FALSE
 	passivePerk = FALSE
-
+	copy_protected = TRUE
 
 /datum/perk/opifex_backup_medical/activate()
 	var/mob/living/carbon/human/user = usr
@@ -374,6 +391,7 @@
 	icon_state = "smuggledarmaments"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/opifex_backup_combat/activate()
 	var/mob/living/carbon/human/user = usr
@@ -395,6 +413,7 @@
 	icon_state = "smuggledcircuit"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/opifex_turret/activate()
 	var/mob/living/carbon/human/user = usr
@@ -416,6 +435,7 @@
 	icon_state = "smuggledpatchkit"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/opifex_patchkit/activate()
 	var/mob/living/carbon/human/user = usr
@@ -437,6 +457,7 @@
 	desc = "Through a combination of pheromones, appearance, and an innate understanding of spider behavior all spiders are friendly to you, they won't attack you even if you attack them. This change \
 	in your biology and pheromones however make you an enemy to roaches. As a side effect of dealing with spiders so often, you can't be slowed or stuck by webbing."
 	icon_state = "muscular" // https://game-icons.net
+	copy_protected = TRUE
 
 /datum/perk/spiderfriend/assign(mob/living/L)
 	..()
@@ -451,6 +472,7 @@
 	desc = "You can spin webs, spreading them around a location as a form of snaring barricade."
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/webmaker/activate()
 	var/mob/living/carbon/human/user = usr
@@ -470,6 +492,7 @@
 	desc = "As a member of the Ru caste your ability to produce chemicals is well known, though it takes an hour to recover and much of your nutritional in-take you can produce clumped ichors that function as medical kits."
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/ichor/activate()
 	var/mob/living/carbon/human/user = usr
@@ -495,6 +518,7 @@
 	name = "Chitin Armor"
 	desc = "Unlike other caste in the cht'mant hive you are built for combat, while not as naturally tough as other species you can tank a few more blows than your softer insectile brethren."
 	icon_state = "paper"
+	copy_protected = TRUE
 
 /datum/perk/chitinarmor/assign(mob/living/L)
 	..()
@@ -512,6 +536,7 @@
 	name = "Scuttlebug"
 	desc = "While your definitive purpose is not as clearly defined as other castes within the cht'mant hive your constant movement and labors have made you quite used to the hustle and bustle, letting you run faster than most races."
 	icon_state = "scuttlebug"
+	copy_protected = TRUE
 
 /datum/perk/repair_goo
 	name = "Produce Repair Goo"
@@ -519,6 +544,7 @@
 	icon_state = "repairgoo"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/repair_goo/activate()
 	var/mob/living/carbon/human/user = usr
@@ -546,6 +572,7 @@
 	icon_state = "modifyoddity"
 	active = FALSE
 	passivePerk = FALSE
+	copy_protected = TRUE
 
 /datum/perk/oddity_reroll/activate()
 	var/mob/living/carbon/human/user = usr
@@ -571,11 +598,13 @@
 	desc = "As a Folken, you can use the light to heal wounds, standing in areas of bright light will increase your natural regeneration."
 	icon_state = "folkenphotohealing"
 	passivePerk = TRUE
+	copy_protected = TRUE
 
 /datum/perk/folken_healing/young
 	name = "Folken Photo-Healing"
 	desc = "As a Folken, you can use the light to heal wounds, standing in areas of bright light will increase your natural regeneration. Due to your comparitively young age, you heal much faster than older folken."
 	var/replaced = FALSE // Did it replace the normal folken healing?
+	copy_protected = TRUE
 
 /datum/perk/folken_healing/young/assign(mob/living/L)
 	..()
@@ -595,6 +624,7 @@
 	desc = "As a mycus, you heal as long as you are in the darkness, increasing your natural regeneration."
 	icon_state = "mycusregeneration"
 	passivePerk = TRUE
+	copy_protected = TRUE
 
 /datum/perk/mushroom_follower
 	name = "Spawn Shroomling"
@@ -605,6 +635,7 @@
 	passivePerk = FALSE
 	var/used = FALSE // Not deleting after use since the description is useful.
 	var/follower_type = /mob/living/carbon/superior/fungi/shroom
+	copy_protected = TRUE
 
 /datum/perk/mushroom_follower/activate()
 	var/mob/living/carbon/human/user = usr
@@ -630,6 +661,7 @@
 	passivePerk = FALSE
 	var/used = FALSE // Not deleting after use since the description is useful.
 	var/follower_type = /mob/living/carbon/superior/fungi/slime
+	copy_protected = TRUE
 
 /datum/perk/slime_follower/activate()
 	var/mob/living/carbon/human/user = usr
@@ -654,6 +686,7 @@
 	based products."
 	icon_state = "carnivore"
 	passivePerk = TRUE
+	copy_protected = TRUE
 
 /datum/perk/herbivore
 	name = "Herbivore"
@@ -661,7 +694,7 @@
 	based products."
 	icon_state = "herbivore"
 	passivePerk = TRUE
-
+	copy_protected = TRUE
 ///////////////////////////////////// Slime perks
 /datum/perk/racial/limb_regen
 	name = "Hypermytosis"
@@ -671,6 +704,7 @@
 	var/cooldown = 5 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 300
+	//This is the ONLY racial perk I am going to allow to be copied.
 
 /datum/perk/racial/limb_regen/activate()
 	if(world.time < cooldown_time)
@@ -699,6 +733,7 @@
 	var/amount_to_boost = 45 // How much the stats are boosted
 	var/duration = 1 MINUTES // How long the stats are boosted for
 	var/blorp = 0 //I'm so sorry.
+	copy_protected = TRUE
 
 /datum/perk/racial/slime_stat_boost/activate()
 	if(world.time < cooldown_time)
@@ -737,6 +772,7 @@
 	var/cooldown = 10 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 200
+	copy_protected = TRUE
 
 /datum/perk/racial/speed_boost/activate()
 	if(world.time < cooldown_time)
@@ -758,6 +794,7 @@
 	icon_state = "gelatinousbiology"
 	passivePerk = TRUE
 	var/regen_rate = 0.3
+	copy_protected = TRUE
 
 /datum/perk/racial/slime_metabolism/on_process()
 	. = ..()

--- a/code/datums/perks/special.dm
+++ b/code/datums/perks/special.dm
@@ -11,6 +11,7 @@
 	active = FALSE
 	passivePerk = FALSE
 	var/anti_cheat= FALSE
+	copy_protected = TRUE
 
 /datum/perk/forceful_rejection/remove()
 	holder.stats.changeStat(STAT_VIV, -15)
@@ -62,6 +63,7 @@
 	lose_text = "It was but a nightmare."
 	icon_state = "celestial"
 	var/statis_amount = 0
+	copy_protected = TRUE // absolutely not
 
 /datum/perk/skill_cap_expanding/assign(mob/living/L)
 	..()
@@ -82,6 +84,7 @@
 	gain_text = "Looking into the stars is starting to becoming productive!"
 	lose_text = "The void above is the same as below."
 	icon_state = "void_eye"
+	copy_protected = TRUE
 
 /datum/perk/skill_cap_addition/assign(mob/living/L)
 	..()

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -113,15 +113,16 @@
 	department = DEPARTMENT_MEDICAL
 	department_flag = MEDICAL
 	faction = MAP_FACTION
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "the Chief Biolab Overseer"
 	difficulty = "Boring to Overwhelming."
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
 	minimum_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor/medStudent
-	department_account_access = TRUE
+	alt_titles = list("Soteria Medical Student"=/decl/hierarchy/outfit/job/medical/doctor/medNurse, "Soteria Medical Intern")
+	department_account_access = FALSE
 	disallow_species = list(FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	access = list(
@@ -130,7 +131,7 @@
 	)
 
 	stat_modifiers = list(
-		STAT_BIO = 40,
+		STAT_BIO = 30,
 		STAT_COG = 10
 	)
 
@@ -227,6 +228,7 @@
 	selection_color = "#a8b69a"
 	alt_titles = list("Soteria Psychologist", "Soteria Empath")
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
+	department_account_access = TRUE
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_psychiatrist, access_chemistry, access_medical_suits, access_eva
 	)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -281,7 +281,7 @@
 	dat += text("Body Temperature: [occ["bodytemp"]-T0C]&deg;C ([occ["bodytemp"]*1.8-459.67]&deg;F)<br><HR>")
 
 	if(occ["borer_present"])
-		dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"
+		dat += "Large Neurophage detected. Ensure patient consent, and remove in a secure environment if they are not wanted.<br>"
 
 	dat += text("[]\tBlood Level %: [] ([] units)</FONT><BR>", ("<font color='[occ["blood_amount"] > 80  ? "blue" : "red"]'>"), occ["blood_amount"], occ["blood_amount"])
 
@@ -377,6 +377,10 @@
 					continue
 				if(istype(I, /obj/item/material/shard/shrapnel))
 					other_wounds += "Embedded shrapnel"
+					continue
+				if(istype(I, /mob/living/simple/borer))
+					var/mob/living/simple/borer/Held = I
+					other_wounds += "Neurophage: [Held.truename]"
 					continue
 				if(istype(I, /obj/item/implant))
 					var/obj/item/implant/device = I

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -228,7 +228,7 @@
 	if (M.getCloneLoss())
 		dat += SPAN_WARNING("Subject appears to have cellular corruption.")
 	if (M.has_brain_worms())
-		dat += SPAN_WARNING("Subject suffering from aberrant brain activity. Recommend further scanning.")
+		dat += SPAN_WARNING("Subject has a second neural pattern. Likely cause: Cortical Borers.")
 	else if (M.getBrainLoss() >= 60 || !M.has_brain())
 		dat += SPAN_WARNING("Subject is brain dead.")
 	else if (M.getBrainLoss() >= 25)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -677,13 +677,13 @@
 	return
 
 /obj/item/storage/box/autoinjectors
-	name = "box of injectors"
-	desc = "Contains auto-injectors."
+	name = "box of emergency sugar injectors"
+	desc = "Contains auto-injectors meant for usage in an uncontrolled borer infection."
 	illustration = "syringe"
 
 /obj/item/storage/box/autoinjectors/populate_contents()
 	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/hypospray/autoinjector(src)
+		new /obj/item/reagent_containers/hypospray/autoinjector/sugar(src)
 
 /obj/item/storage/box/lights
 	name = "box of replacement bulbs"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -63,7 +63,7 @@
 	switch(damage_type)
 		if(BRUTE)
 			if(!edge)
-				if(sharp) // dont even fucking ask whats the difference between this and eyes get_possible_wounds. I dont know, I wont tell you. 
+				if(sharp) // dont even fucking ask whats the difference between this and eyes get_possible_wounds. I dont know, I wont tell you.
 					if(is_organic)
 						LAZYADD(possible_wounds, subtypesof(/datum/component/internal_wound/organic/brain_sharp))
 					if(is_robotic)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -192,9 +192,13 @@
 		var/mob/living/carbon/human/H = M
 		if(H.species.name == src.species.name)
 			return
-
+		log_and_message_admins("[key_name(src)] sent a telepathic (borer) message to [key_name(M)]: [text]")
 		to_chat(H, SPAN_WARNING("Your nose begins to bleed..."))
-		H.drip_blood(1)
+		H.drip_blood(25)
+		if(prob(5))
+			var/obj/item/organ/internal/vital/brain/B = H.internal_organs_by_efficiency[BP_BRAIN]
+			B.take_damage(1,BRUTE, 2, FALSE, FALSE, FALSE)
+
 
 
 /mob/living/carbon/human/proc/psychic_whisper(mob/M as mob in oview())
@@ -207,4 +211,5 @@
 		log_say("PsychicWhisper: [key_name(src)]->[M.key] : [msg]")
 		to_chat(M, "\green You hear a strange, alien voice in your head... \italic [msg]")
 		to_chat(src, "\green You said: \"[msg]\" to [M]")
+		log_and_message_admins("[key_name(src)] sent a telepathic (borer) message to [key_name(M)]: [msg]")
 	return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1054,6 +1054,10 @@
 		var/image/holder = hud_list[LIFE_HUD]
 		if(stat == DEAD)
 			holder.icon_state = "huddead"
+		else if(status_flags & XENO_HOST)
+			holder.icon_state = "hudxeno"
+		else if (has_brain_worms())
+			holder.icon_state = "hudbrainworm"
 		else
 			holder.icon_state = "hudhealthy"
 		hud_list[LIFE_HUD] = holder
@@ -1064,12 +1068,8 @@
 			holder.icon_state = "huddead"
 		else if(status_flags & XENO_HOST)
 			holder.icon_state = "hudxeno"
-		else if(has_brain_worms())
-			var/mob/living/simple/borer/B = has_brain_worms()
-			if(B.controlling)
-				holder.icon_state = "hudbrainworm"
-			else
-				holder.icon_state = "hudhealthy"
+		else if (has_brain_worms())
+			holder.icon_state = "hudbrainworm"
 		else
 			holder.icon_state = "hudhealthy"
 
@@ -1078,7 +1078,7 @@
 			holder2.icon_state = "huddead"
 		else if(status_flags & XENO_HOST)
 			holder2.icon_state = "hudxeno"
-		else if(has_brain_worms())
+		else if (has_brain_worms())
 			holder2.icon_state = "hudbrainworm"
 		else
 			holder2.icon_state = "hudhealthy"

--- a/code/modules/organs/external/dismemberment.dm
+++ b/code/modules/organs/external/dismemberment.dm
@@ -7,7 +7,24 @@
 
 	if(cannot_amputate || !owner)
 		return
-
+	//Ugh.
+	if(organ_tag == BP_HEAD) //UGLY UGLY UGLY
+		if(owner.has_brain_worms())
+			var/mob/living/simple/borer/B = owner.has_brain_worms()
+			if(B)
+				B.leave_host()
+				B.reset_view(null) //Camera bug.
+				to_chat(owner, SPAN_NOTICE("Your host has been decapitated! Resist to leave their dismembered head!"))
+				B.detatch()
+				B.emergency_leave = TRUE
+				if(!B.ckey && owner.ckey && B.controlling)
+					B.ckey = owner.ckey
+					B.controlling = 0
+				if(B.host_brain?.ckey)
+					owner.ckey = B.host_brain.ckey //this will technically allow you to be revived by just attaching any head and brain but whatever bro fixing it is so ass
+					B.host_brain.ckey = null
+					B.host_brain.name = "host brain"
+					B.host_brain.real_name = "host brain"
 	switch(disintegrate)
 		if(DISMEMBER_METHOD_EDGE)
 			if(!clean)
@@ -94,5 +111,4 @@
 					continue
 				I.forceMove(get_turf(src))
 				I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
-
 			qdel(src)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -84,7 +84,7 @@
 	var/contained = reagents.log_list()
 	var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
 	admin_inject_log(user, M, src, contained, trans)
-	to_chat(user, SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in \the [src]."))	
+	to_chat(user, SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in \the [src]."))
 	return
 
 /obj/item/reagent_containers/hypospray/verb/empty()
@@ -114,6 +114,13 @@
 	var/can_be_refilled = TRUE //For cargos
 	var/baseline_sprite = "syrette_inopravoline" //Mostly used for chemmasters so we dont need to init(sprite name), to allow mid-round changing of icons.
 	injtime = 2 //Instant was a bit to powerful well refilling
+
+/obj/item/reagent_containers/hypospray/autoinjector/sugar
+	name = "autoinjector (Emergency Glucose)"
+	desc = "A Soteria proprietary injector. Meant for even the most dull-minded individuals, these are marked with a stylized symbol of a Cortical Borer. For emergencies, rogue borers, and-or diabetic shock."
+	preloaded_reagents = list("sugar" = 5)
+	can_be_refilled = FALSE
+	injtime = 5
 
 /obj/item/reagent_containers/hypospray/autoinjector/examine(mob/user)
 	..()

--- a/modular_sojourn/Borers/__ADMIN SHIT/antagonist.dm
+++ b/modular_sojourn/Borers/__ADMIN SHIT/antagonist.dm
@@ -5,10 +5,10 @@
 	role_text_plural = "Cortical Borers"
 	mob_path = /mob/living/simple/borer/roundstart
 	bantype = ROLE_BANTYPE_BORER
-	welcome_text = "Use your Infest power to crawl into the ear of a host and fuse with their brain. You can only take control temporarily, and at risk of hurting your host, so be clever and careful; your host is encouraged to help you however they can. Talk to your fellow borers with :x."
+	welcome_text = "You are a cortical borer. An ancient Neurophage that has recently awoken, being both hiveminded, and having just awoken - you are understandably quite confused in this new world. Still, not everything is bad. Your psionic abilities remain just as sharp, your neural lance primed - and more importantly, an abundance of new hosts; though the One Mind has seemingly decided to take a new direction. Subtlety. For now, obey the treaty you have signed (if you are a Colony-spawned Borer!) to the best of your abilities. Speak with your fellow borers using :x, and remember. You ARE an antagonist, but this is not a license to avoid roleplay! You exist to enrich it."
 	antaghud_indicator = "hudborer"
 
-	outer = TRUE
+	outer = FALSE //Borers are only spawned via mapping spawns now. Don't teleport them randomly.
 	only_human = FALSE
 
 /datum/antagonist/borer/reproduced	//This antag datum will prevent all borers be rounstart


### PR DESCRIPTION
## About The Pull Request
Due to el canon event, reworks borers, fixes several bugs, fixes a softlock involving their levelling.

THIS IS NOT DONE. IT CAN HOWEVER BE TESTMERGED WITHOUT CONSEQUENCE
## Changelog
-Borer Base Chems buffed
-Borer Chem per Level buffed
-Borer EXP raised for certain actions
-Borer EXP requirements raised for revival
-Invisibility now actually drains faster than borers regen chems. Lol!
-bugfixes
-Softlock fixes
-Truename is now able to be changed post-spawn ONCE.
-Hopefully fixes Commune with Human
-Fixes Borers not being logged in any significant capacity (you could psychically harass people)
-Buffs Jumpstart (it was softlockable)

note this was coded at 4:30 AM+ but everything has been mostly tested and works other than the health hud changes ig

should go without saying but if you map these in you should be extraordinarily careful with how you treat them.