### PR TITLE
Notifies Players on Too-New Version

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -162,6 +162,10 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/list/forbidden_versions = list() // Clients with these byond versions will be autobanned. Format: string "byond_version.byond_build"; separate with ; in config, e.g. 512.1234;512.1235
 	var/minimum_byond_version
 	var/minimum_byond_build
+	var/maximum_byond_version
+	var/maximum_byond_build
+	var/byond_version_upgrade_message = "Your BYOND version is too old. Please upgrade to a newer version to connect."
+	var/byond_version_downgrade_message = "Your BYOND version is too new and may be unstable. Please downgrade to an older version to connect."
 
 	var/enter_allowed = 1
 
@@ -645,6 +649,18 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				if("minimum_byond_build")
 					config.minimum_byond_build = text2num(value)
+
+				if("maximum_byond_version")
+					config.maximum_byond_version = text2num(value)
+
+				if("maximum_byond_build")
+					config.maximum_byond_build = text2num(value)
+
+				if("byond_version_upgrade_message")
+					config.byond_version_upgrade_message = value
+
+				if("byond_version_downgrade_message")
+					config.byond_version_downgrade_message = value
 
 				if("irc_bot_host")
 					config.irc_bot_host = value

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -302,7 +302,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(config.minimum_byond_version && byond_version < config.minimum_byond_version)
 		to_chat(src, span_userdanger("Your BYOND version is too old."))
 		to_chat(src, span_danger("This server requires BYOND version [config.minimum_byond_version] or higher. You are using version [byond_version]."))
-		to_chat(src, span_danger("Please update to a newer version of BYOND."))
+		to_chat(src, span_danger("[config.byond_version_upgrade_message]"))
 		if(connecting_admin)
 			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider updating BYOND.")
 		else
@@ -313,7 +313,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(config.minimum_byond_build && byond_build && byond_build < config.minimum_byond_build)
 		to_chat(src, span_userdanger("Your BYOND build is too old."))
 		to_chat(src, span_danger("This server requires BYOND build [config.minimum_byond_build] or higher. You are using build [byond_build]."))
-		to_chat(src, span_danger("Please update to a newer version of BYOND."))
+		to_chat(src, span_danger("[config.byond_version_upgrade_message]"))
 		if(connecting_admin)
 			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider updating BYOND.")
 		else
@@ -322,25 +322,17 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	// Check maximum BYOND version
 	if(config.maximum_byond_version && byond_version > config.maximum_byond_version)
-		to_chat(src, span_userdanger("Your BYOND version is too new."))
-		to_chat(src, span_danger("This server requires BYOND version [config.maximum_byond_version] or lower. You are using version [byond_version]."))
-		to_chat(src, span_danger("Please downgrade to an older version of BYOND or wait for server compatibility to be updated."))
-		if(connecting_admin)
-			to_chat(src, "As an admin, you are being allowed to continue using this version, but please be aware of potential compatibility issues.")
-		else
-			qdel(src)
-			return
+		to_chat(src, span_warning("Your BYOND version is newer than recommended."))
+		to_chat(src, span_warning("This server is optimized for BYOND version [config.maximum_byond_version] or lower. You are using version [byond_version]."))
+		to_chat(src, span_warning("[config.byond_version_downgrade_message]"))
+		to_chat(src, span_notice("You have been allowed to connect, but you may experience compatibility issues."))
 
 	// Check maximum BYOND build
 	if(config.maximum_byond_build && byond_build && byond_build > config.maximum_byond_build)
-		to_chat(src, span_userdanger("Your BYOND build is too new."))
-		to_chat(src, span_danger("This server requires BYOND build [config.maximum_byond_build] or lower. You are using build [byond_build]."))
-		to_chat(src, span_danger("Please downgrade to an older version of BYOND or wait for server compatibility to be updated."))
-		if(connecting_admin)
-			to_chat(src, "As an admin, you are being allowed to continue using this version, but please be aware of potential compatibility issues.")
-		else
-			qdel(src)
-			return
+		to_chat(src, span_warning("Your BYOND build is newer than recommended."))
+		to_chat(src, span_warning("This server is optimized for BYOND build [config.maximum_byond_build] or lower. You are using build [byond_build]."))
+		to_chat(src, span_warning("[config.byond_version_downgrade_message]"))
+		to_chat(src, span_notice("You have been allowed to connect, but you may experience compatibility issues."))
 
 	// if (connection == "web" && !connecting_admin)
 	// 	if (!CONFIG_GET(flag/allow_webclient))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -298,6 +298,49 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	winset(src, null, "command=\".configure graphics-hwmode on\"")
 
 	/* byond err version check here (configurable) */
+	// Check minimum BYOND version
+	if(config.minimum_byond_version && byond_version < config.minimum_byond_version)
+		to_chat(src, span_userdanger("Your BYOND version is too old."))
+		to_chat(src, span_danger("This server requires BYOND version [config.minimum_byond_version] or higher. You are using version [byond_version]."))
+		to_chat(src, span_danger("Please update to a newer version of BYOND."))
+		if(connecting_admin)
+			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider updating BYOND.")
+		else
+			qdel(src)
+			return
+
+	// Check minimum BYOND build
+	if(config.minimum_byond_build && byond_build && byond_build < config.minimum_byond_build)
+		to_chat(src, span_userdanger("Your BYOND build is too old."))
+		to_chat(src, span_danger("This server requires BYOND build [config.minimum_byond_build] or higher. You are using build [byond_build]."))
+		to_chat(src, span_danger("Please update to a newer version of BYOND."))
+		if(connecting_admin)
+			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider updating BYOND.")
+		else
+			qdel(src)
+			return
+
+	// Check maximum BYOND version
+	if(config.maximum_byond_version && byond_version > config.maximum_byond_version)
+		to_chat(src, span_userdanger("Your BYOND version is too new."))
+		to_chat(src, span_danger("This server requires BYOND version [config.maximum_byond_version] or lower. You are using version [byond_version]."))
+		to_chat(src, span_danger("Please downgrade to an older version of BYOND or wait for server compatibility to be updated."))
+		if(connecting_admin)
+			to_chat(src, "As an admin, you are being allowed to continue using this version, but please be aware of potential compatibility issues.")
+		else
+			qdel(src)
+			return
+
+	// Check maximum BYOND build
+	if(config.maximum_byond_build && byond_build && byond_build > config.maximum_byond_build)
+		to_chat(src, span_userdanger("Your BYOND build is too new."))
+		to_chat(src, span_danger("This server requires BYOND build [config.maximum_byond_build] or lower. You are using build [byond_build]."))
+		to_chat(src, span_danger("Please downgrade to an older version of BYOND or wait for server compatibility to be updated."))
+		if(connecting_admin)
+			to_chat(src, "As an admin, you are being allowed to continue using this version, but please be aware of potential compatibility issues.")
+		else
+			qdel(src)
+			return
 
 	// if (connection == "web" && !connecting_admin)
 	// 	if (!CONFIG_GET(flag/allow_webclient))

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -4,8 +4,8 @@
 #Final authority on what's required to fully build the project
 
 # byond version
-export BYOND_MAJOR=514
-export BYOND_MINOR=1568
+export BYOND_MAJOR=515
+export BYOND_MINOR=1647
 
 #rust_g git tag
 export RUST_G_VERSION=3.2.0


### PR DESCRIPTION
Says what it does on the box. Adds new config variables that prevents too-old players from joining, and notifies too-new players that they need to downgrade.