### PR TITLE
mech armor rework.

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -2,7 +2,7 @@
 	force = 30
 	internal_damage_threshold = 50
 	maint_access = 0
-	damage_absorption = list("brute"=0.7,"fire"=1,"bullet"=0.7,"energy"=1,"bomb"=0.8)
+	damage_absorption = list("brute"=30,"melee"=30,"fire"=1,"bullet"=30,"energy"=30,"bomb"=0.8)
 	cargo_capacity = 5
 
 /obj/mecha/combat/moved_inside(mob/living/carbon/human/H)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -9,7 +9,7 @@
 	dir_in = 1 //Facing North.
 	health = 1400
 	deflect_chance = 20
-	damage_absorption = list("brute"=0.5,"fire"=1.1,"bullet"=0.65,"energy"=0.9,"bomb"=1)
+	damage_absorption = list("brute"=35,"melee"=35,"fire"=1.1,"bullet"=35,"energy"=35,"bomb"=1)
 	armor_level = MECHA_ARMOR_HEAVY
 	max_temperature = 30000
 	price_tag = 25000

--- a/code/game/mecha/combat/greyson.dm
+++ b/code/game/mecha/combat/greyson.dm
@@ -10,7 +10,7 @@
 	dir_in = 1 //Facing North.
 	health = 1500
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.5,"fire"=0.7,"bullet"=0.45,"energy"=0.7,"bomb"=0.7)
+	damage_absorption = list("brute"=50,"melee"=50,"fire"=0.7,"bullet"=50,"energy"=50,"bomb"=0.7)
 	max_temperature = 60000
 	infra_luminosity = 3
 	armor_level = MECHA_ARMOR_SUPERHEAVY

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -10,7 +10,7 @@
 	dir_in = 1 //Facing North.
 	health = 900
 	deflect_chance = 15
-	damage_absorption = list("brute"=0.75,"fire"=1,"bullet"=0.8,"energy"=0.85,"bomb"=1)
+	damage_absorption = list("brute"=25,"melee"=25,"fire"=1,"bullet"=25,"energy"=25,"bomb"=1)
 	armor_level = MECHA_ARMOR_SCOUT
 	max_temperature = 25000
 	price_tag = 25000
@@ -44,7 +44,7 @@
 	armor_level = MECHA_ARMOR_LIGHT
 	health = 750
 	deflect_chance = 10
-	damage_absorption = list("brute"=0.85,"fire"=1,"bullet"=0.9,"energy"=0.95,"bomb"=1)
+	damage_absorption = list("brute"=10,"melee"=10,"fire"=1,"bullet"=10,"energy"=10,"bomb"=1)
 	price_tag = 10000
 	internal_damage_threshold = 45
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax/marshals
@@ -76,7 +76,7 @@
 	initial_icon = "darkgygax"
 	health = 1200
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.6,"fire"=0.8,"bullet"=0.6,"energy"=0.65,"bomb"=0.8)
+	damage_absorption = list("brute"=30,"melee"=30,"fire"=0.8,"bullet"=30,"energy"=30,"bomb"=0.8)
 	max_temperature = 45000
 	leg_overload_coeff = 1
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax/dark

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -9,7 +9,7 @@
 	price_tag = 25000 //Rare spawns + uncraftable
 	health = 1500
 	deflect_chance = 25
-	damage_absorption = list("brute"=0.5,"fire"=0.7,"bullet"=0.45,"energy"=0.7,"bomb"=0.7)
+	damage_absorption = list("brute"=50,"melee"=50,"fire"=0.7,"bullet"=50,"energy"=50,"bomb"=0.7)
 	max_temperature = 60000
 	infra_luminosity = 3
 	armor_level = MECHA_ARMOR_SUPERHEAVY

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -9,7 +9,7 @@
 	step_energy_drain = 3
 	health = 600
 	deflect_chance = 30
-	damage_absorption = list("brute"=0.7,"fire"=0.7,"bullet"=0.7,"energy"=0.7,"bomb"=0.7)
+	damage_absorption = list("brute"=25,"melee"=25,"fire"=0.7,"bullet"=25,"energy"=25,"bomb"=0.7)
 	armor_level = MECHA_ARMOR_MEDIUM
 	max_temperature = 25000
 	price_tag = 40000

--- a/code/game/mecha/equipment/tools/passive_tools.dm
+++ b/code/game/mecha/equipment/tools/passive_tools.dm
@@ -18,18 +18,19 @@
 	force = 0
 	required_type = /obj/mecha
 	matter = list(MATERIAL_STEEL = 15) //Its only 30 damage compared to the 15 steel 60 damage sword
-	var/damage_reduction = 0.1
+	var/extra_armor = 15
 	selectable = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/fist_plating/attach(obj/mecha/M)
 	. = ..()
-	for(var/i in chassis.damage_absorption)
-		chassis.damage_absorption[i] -= damage_reduction
+	chassis.damage_absorption[BRUTE] += extra_armor
+	chassis.damage_absorption[ARMOR_MELEE] += extra_armor
+
 	update_chassis_page()
 
 /obj/item/mecha_parts/mecha_equipment/fist_plating/detach(atom/moveto=null)
-	for(var/i in chassis.damage_absorption)
-		chassis.damage_absorption[i] += damage_reduction
+	chassis.damage_absorption[BRUTE] -= extra_armor
+	chassis.damage_absorption[ARMOR_MELEE] -= extra_armor
 	. = ..()
 
 /obj/item/mecha_parts/mecha_equipment/fist_plating/get_equip_info()
@@ -46,6 +47,7 @@
 	range = 0
 	var/deflect_coeff = 1
 	var/damage_coeff = 1
+	var/extra_armor = 0
 	var/melee
 	selectable = FALSE
 
@@ -88,6 +90,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_SILVER = 5)
 	deflect_coeff = 1.15
 	damage_coeff = 0.8
+	extra_armor = 10
 	melee = 1
 	price_tag = 600
 
@@ -95,6 +98,7 @@
 	if(..())
 		chassis.m_deflect_coeff *= deflect_coeff
 		chassis.m_damage_coeff *= damage_coeff
+		chassis.m_armor_addition += extra_armor
 		chassis.mhit_power_use += energy_drain
 
 
@@ -102,6 +106,7 @@
 	if(..())
 		chassis.m_deflect_coeff /= deflect_coeff
 		chassis.m_damage_coeff /= damage_coeff
+		chassis.m_armor_addition -= extra_armor
 		chassis.mhit_power_use -= energy_drain
 
 
@@ -113,6 +118,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_GOLD = 5)
 	deflect_coeff = 1.15
 	damage_coeff = 0.8
+	extra_armor = 10
 	melee = 0
 	price_tag = 600
 
@@ -120,12 +126,14 @@
 	if(..())
 		chassis.r_deflect_coeff *= deflect_coeff
 		chassis.r_damage_coeff *= damage_coeff
+		chassis.r_armor_addition += extra_armor
 		chassis.rhit_power_use += energy_drain
 
 /obj/item/mecha_parts/mecha_equipment/armor_booster/antiproj_armor_booster/deactivate_boost()
 	if(..())
 		chassis.r_deflect_coeff /= deflect_coeff
 		chassis.r_damage_coeff /= damage_coeff
+		chassis.r_armor_addition -= extra_armor
 		chassis.rhit_power_use -= energy_drain
 
 

--- a/code/game/mecha/equipment/weapons/ranged/mech_ammunition.dm
+++ b/code/game/mecha/equipment/weapons/ranged/mech_ammunition.dm
@@ -43,8 +43,8 @@
 	name = "25mm ammunition box"
 	desc = "A heavy duty box with a feeder containing ammunition for a mech-mounted heavy machinegun."
 	icon_state = "boxhrifle-practice"
-	ammo_amount_left = 200
-	ammo_max_amout = 200
+	ammo_amount_left = 360
+	ammo_max_amout = 360
 	amount_per_click = 40 //Hack to make them impossable to go into negitives / It can still go into negatives
 	ammo_type = CAL_MECH_MACHINEGUN
 	price_tag = 30
@@ -57,8 +57,8 @@
 	name = "60mm HEAD ammunition box"
 	desc = "A heavy duty box with a feeder containing ammunition for a full-sized autocannon."
 	icon_state = "boxhrifle-practice"
-	ammo_amount_left = 40
-	ammo_max_amout = 40
+	ammo_amount_left = 80
+	ammo_max_amout = 80
 	amount_per_click = 10
 	ammo_type = CAL_MECH_AUTOCANNON
 	price_tag = 30
@@ -67,8 +67,8 @@
 	name = "30mm HEAD ammunition box"
 	desc = "A heavy duty box with a feeder containing ammunition for a mech-sized autocannon."
 	icon_state = "boxhrifle-practice"
-	ammo_amount_left = 60
-	ammo_max_amout = 60
+	ammo_amount_left = 180
+	ammo_max_amout = 180
 	amount_per_click = 30
 	ammo_type = CAL_MECH_ULTRACANNON
 	price_tag = 30
@@ -81,8 +81,8 @@
 	name = "50mm HEAD ammunition box"
 	desc = "A heavy duty box with a feeder containing ammunition for a flak cannon."
 	icon_state = "boxhrifle-hv"
-	ammo_amount_left = 30
-	ammo_max_amout = 30
+	ammo_amount_left = 90
+	ammo_max_amout = 90
 	ammo_type = CAL_MECH_SHOTGUN
 	price_tag = 30
 

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -24,7 +24,7 @@
 	price_tag = 6500
 	health = 550
 	lights_power = 8
-	damage_absorption = list("brute"=0.8,"fire"=0.5,"bullet"=0.8,"energy"=1,"bomb"=0.5)
+	damage_absorption = list("brute"=8,"melee"=8,"fire"=0.5,"bullet"=8,"energy"=8,"bomb"=0.5)
 	armor_level = MECHA_ARMOR_SCOUT
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/firefighter
 
@@ -39,6 +39,8 @@
 	opacity = 0
 	lights_power = 60
 	health = 750
+	damage_absorption = list("brute"=9,"melee"=9,"fire"=0.5,"bullet"=9,"energy"=9,"bomb"=0.5)
+	armor_level = MECHA_ARMOR_SCOUT
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/deathripley
 	price_tag = 7000
 


### PR DESCRIPTION
## About The Pull Request

Reworks armor for mechs to be subtractive instead of multiplicative like our current armor system. Additionally improved the ammo capacity of mech ammo boxes to help them endure longer engagement fights like with maints roaches and expeditions.

I do not recommend merging this PR until a good balance is found between PVE content and PVP. So far this is balanced around PVP but it makes trips like to greysons trivial by taking absolutely no damage as most enemies do like 15 with an AD of 2 at most while most common damage is something like 10. This makes every number I suggested here VERY experimental and I would highly encourage suggestions and ideas. I was already thinking about a mix between low armor but high health as well to fix the pure immunity of mechs against PVE content.

## Changelog
Mechs now use the new subtractive armor system instead of the old multiplicative.
Mechs ammo boxes ammo capacity has been buffed.
