### PR TITLE
remove unmaker blacklist for SST guns

### DIFF
--- a/code/modules/projectiles/guns/energy/projectile/sst.dm
+++ b/code/modules/projectiles/guns/energy/projectile/sst.dm
@@ -22,7 +22,7 @@
 	projectile_type=/obj/item/projectile/bullet/pistol_35/rubber/soporific
 	price_tag = 1750
 	serial_type = "SI"
-	blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = TRUE) // I can't believe I have to do this. Don't turn NL weapons into literal war crimes.
+	// blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = TRUE)
 
 /obj/item/gun/energy/sst/preloaded
 


### PR DESCRIPTION
## About The Pull Request
removes the blacklist for the unmaker on account of the unmaker is now damn near unobtainable with it being restricted to only dropping from the greyson boss mechs, odds you get one is low both from droprate and the prospectors actually selling one to you. just not really a viable nerf to the weapons since the object is now insanely rare
## Changelog
comments out the blacklist for the unmaker for SSTs