### PR TITLE
Gives robots OOC notes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -400,6 +400,7 @@
 			flavor_text = module_flavour
 		else
 			flavor_text = client.prefs.flavour_texts_robot["Default"]
+		ooc_text = client.prefs.ooc_text
 
 /mob/living/silicon/robot/verb/Namepick()
 	set category = "Silicon Commands"


### PR DESCRIPTION
## About The Pull Request
port from soj, which is ported from equinox. does what the title says, allowing Cyborgs to have OOC notes, something that should've been ported by now
## Changelog
gives cyborgs access to having OOC notes 

why has nobody done this yet
<img width="449" height="682" alt="image" src="https://github.com/user-attachments/assets/be7f32b1-e48d-42c7-a4be-28f7aa5ec697" />
