### PR TITLE
Gives the SCAF suit 100 rad armor

### DIFF
--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -9,7 +9,7 @@
 		energy = 12,
 		bomb = 75,
 		bio = 100,
-		rad = 25
+		rad = 100
 	)
 	siemens_coefficient = 0.35
 	species_restricted = list("Human")
@@ -56,7 +56,7 @@
 		energy = 12,
 		bomb = 75,
 		bio = 100,
-		rad = 25
+		rad = 100
 	)
 	siemens_coefficient = 0.35
 	species_restricted = list("Human")


### PR DESCRIPTION
## About The Pull Request
the SCAF suit is a bioproof, space proof heavy piece of armor. it makes total sense that it would be rad proof, its meant to be a big heavy armor that gives you good protection in trade for slowing you down and 25 rad armor isn't even close to "good" protection against radiation. the blood red voidsuit literally is more radproof than this thing was/is

blackshield buff i guess?
## Changelog
Changes merc.dm to give the SCAF 100 rad armor