### PR TITLE
Readds the nanogate to both FBPs and Synthetics 

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -62,7 +62,7 @@
 		/datum/job/ai
 		)
 	allow_modifications = TRUE
-	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_AGSYNTH)
+	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_AGSYNTH, FORM_SOTSYNTH, FORM_BSSYNTH, FORM_UNBRANDED, FORM_FBP)
 
 /datum/category_item/setup_option/core_implant/artificer_nanogate
 	name = "Artificer Nanogate"


### PR DESCRIPTION
## About The Pull Request
since FBPs and Synths got their self surgery nerfed, they can finally get some level of buff. like the reverting of Rebel's removal of the nanogate from FBPs and Synthethics, booyah
## Changelog
readds the synthetics and FBPs to the nanogate in core_implants.dm