### PR TITLE
Matter fix

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -861,6 +861,7 @@ var/datum/feed_network/news_network = new /datum/feed_network     //The global n
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "newspaper"
 	matter = list(MATERIAL_BIOMATTER = 2)
+	ignore_object_materials = TRUE
 	w_class = ITEM_SIZE_SMALL	//Let's make it fit in trashbags!
 	attack_verb = list("bapped")
 	var/screen = 0

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -3,7 +3,7 @@
 	name = "wet floor sign"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "caution"
-	matter = list(MATERIAL_BIOMATTER = 2, MATERIAL_PLASTIC = 3)
+	matter = list(MATERIAL_PLASTIC = 3)
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS
 	throw_speed = 1


### PR DESCRIPTION
## About The Pull Request
Fixes Wet Floor Sign requiring biomatter
## Changelog
Removed Biomatter from Matter list from caution.dm
added ignore_object_materials = TRUE to newscaster.dm to hopefully prevent newscasters from requiring biomatter to print newspaper.