### PR TITLE
BORIS Modules, few borg weapon buffs, reintroduction of the humble posibrain

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/robot_parts.dm
@@ -235,6 +235,41 @@
 
 		qdel(src)
 
+	if(istype(W, /obj/item/borg/upgrade/boris))
+		var/obj/item/borg/upgrade/boris/M = W
+		if(!is_ready(user))
+			to_chat(user, SPAN_WARNING("The Remote Link must go in after everything else!"))
+			return
+		if(!istype(loc,/turf))
+			to_chat(user, SPAN_WARNING("You can't put \the [W] in, the frame has to be standing on the ground to be perfectly precise."))
+			return
+		var/mob/living/silicon/robot/O = new (get_turf(loc), unfinished = 1)
+		if(!O)	return
+
+		user.unEquip(M)
+
+		O.invisibility = 0
+		O.custom_name = created_name
+		O.updatename("Default")
+
+		var/obj/item/robot_parts/chest/chest = parts["chest"]
+		O.cell = chest.cell
+		O.cell.forceMove(O)
+		//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
+		W.forceMove(O)
+
+		// Since we "magically" installed a cell, we also have to update the correct component.
+		if(O.cell)
+			var/datum/robot_component/cell_component = O.components["power cell"]
+			cell_component.wrapped = O.cell
+			cell_component.installed = 1
+
+		callHook("borgify", list(O))
+
+		qdel(src)
+		O.stat = 2 //FORCE STAT = 2 to allow the AI to take control of the shell
+
+
 	if (istype(W, /obj/item/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", src.name, src.created_name), MAX_NAME_LEN)
 		if (!t)

--- a/code/modules/projectiles/guns/energy/misc/robotguns.dm
+++ b/code/modules/projectiles/guns/energy/misc/robotguns.dm
@@ -11,7 +11,7 @@
 	cell_type = /obj/item/cell/medium/greyson
 	modifystate = null
 	force = WEAPON_FORCE_PAINFUL
-	charge_cost = 200
+	charge_cost = 120 //200 was excessive for this thing's cooldowns.
 	self_recharge = 1
 	init_firemodes = list(
 		list(mode_name="beanbag", projectile_type=/obj/item/projectile/bullet/shotgun/beanbag, fire_sound = 'sound/weapons/guns/fire/shotgun_combat.ogg', fire_delay=25, icon="stun"),
@@ -23,26 +23,28 @@
 	charge_meter = FALSE
 
 /obj/item/gun/energy/bsrifle
-	name = "integrated \"STS\" Burst rifle"
+	name = "integrated \"STS\" Rifle"
 	desc = "A lightweight modified variant of the STS-PARA that has been modified to serve as the main-arm for a combat bot, much of its comfort features have been\
-	removed in order to optimize space for an integral flash-synthesizer hooked directly to its power, keeping it flush with ammo as long as the power supply is steady."
+	removed in order to optimize space for an integral flash-synthesizer hooked directly to its power, keeping it flush with ammo as long as the power supply is steady; though decreasing rate of fire as a result."
 	icon = 'icons/obj/robot_items.dmi'
 	icon_state = "security_rifle"
 	item_state = "security_rifle"
-	damage_multiplier = 1.3
+	damage_multiplier = 1.19 //Damage Multiplier Decrease. These are pretty destructive even as is
 	cell_type = /obj/item/cell/medium/greyson
 	modifystate = null
 	force = WEAPON_FORCE_PAINFUL
-	charge_cost = 80 //about 20 rounds per full charge
+	charge_cost = 65 //24 round max capacity - can sustain fire for 15 seconds then has to disengage for around 25
 	self_recharge = 1
+	recharge_time = 5 // Every 5 ticks
+	recharge_amount = 150 // Approximately 3 rounds (per 3 seconds)
 	charge_meter = TRUE
 	serial_type = "NM"
 	init_firemodes = list(
-		list(mode_name="Rubbers Burst", projectile_type=/obj/item/projectile/bullet/rifle_75/rubber, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', burst = 2 ,fire_delay = 10, icon="burst"),
-		list(mode_name="Standard Burst", projectile_type=/obj/item/projectile/bullet/rifle_75, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', burst = 2 ,fire_delay = 10, icon="burst"),
-		list(mode_name="Hollowpoint Burst", projectile_type=/obj/item/projectile/bullet/rifle_75/lethal, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', burst = 2 , fire_delay = 10,  icon="burst"),
-		list(mode_name="Incendiary Burst", projectile_type=/obj/item/projectile/bullet/rifle_75/incend, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', burst = 2, fire_delay = 20, icon="burst"),
-		)
+		list(mode_name="Rubber Munitions", projectile_type=/obj/item/projectile/bullet/rifle_75/rubber, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', mode_type = /datum/firemode/automatic,  fire_delay = 2, icon="burst"),
+		list(mode_name="Standard Munitions", projectile_type=/obj/item/projectile/bullet/rifle_75, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', mode_type = /datum/firemode/automatic,  fire_delay = 3, icon="burst"),
+		list(mode_name="Hollowpoint Munitions", projectile_type=/obj/item/projectile/bullet/rifle_75/lethal, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', mode_type = /datum/firemode/automatic,  fire_delay = 3.5,  icon="burst"),
+		list(mode_name="Incendiary Munitions", projectile_type=/obj/item/projectile/bullet/rifle_75/incend, fire_sound = 'sound/weapons/guns/fire/NM_PARA.ogg', mode_type = /datum/firemode/automatic,  fire_delay = 3.5, icon="burst")
+		) //Burst fire felt like dogshit, I'd rather use a slightly slower full auto mode.
 
 /obj/item/gun/energy/dazzlation //the last gun you'll ever need.
 	name = "integrated \"Dazlation\" light pistol"
@@ -64,20 +66,25 @@
 		)
 
 /obj/item/gun/energy/borg/pistol
-	name = "\"Disabler\" pistol"
-	desc = "A standardised ammunition-synthesizing pistol superficialy resembling an ancient pistol."
+	name = "\"Glockinator\" Integrated Autopistol"
+	desc = "An ammo-synthensizing pistol based off of ancient, recovered designs from Old Earth Culture. This one has a flash-munitions synthensizer hidden within a drum magazine\
+	  And a 'switch' present on the back, capable of alternating between single-shot and full-auto. Supposedly extremely inaccurate."
 	icon = 'icons/obj/guns/projectile/glock.dmi'
 	icon_state = "glock"
 	item_state = "glock"
 	cell_type = /obj/item/cell/medium/greyson
 	modifystate = null
-	charge_cost = 100
+	charge_cost = 50 //This was so terrible it was hard to describe.
+	recharge_time = 2 //Incredibly fast recharge time.
+	recharge_amount = 100 //2 rounds per 2 ticks. Not enough to sustain continous fire, but enough to justify it's god-awful damage output
+	init_recoil = SMG_RECOIL(0.4) //Hard to control accurately in most cases.
 	self_recharge = 1
 	init_firemodes = list(
-		list(mode_name="rubber bullet", projectile_type=/obj/item/projectile/bullet/pistol_35/rubber, fire_sound = 'sound/weapons/guns/fire/9mm_pistol.ogg', fire_delay=10
-		, icon="stun"),
-		list(mode_name="Hollowpoint round", projectile_type=/obj/item/projectile/bullet/pistol_35/lethal, fire_sound='sound/weapons/guns/fire/9mm_pistol.ogg', fire_delay=5, icon="kill"),
-		)
+		list(mode_name="Rubber Bullet (Single)", projectile_type=/obj/item/projectile/bullet/pistol_35/rubber, fire_sound = 'sound/weapons/guns/fire/9mm_pistol.ogg', fire_delay=3, icon="stun"),
+		list(mode_name="Hollowpoint Round (Single)", projectile_type=/obj/item/projectile/bullet/pistol_35/lethal, fire_sound='sound/weapons/guns/fire/9mm_pistol.ogg', fire_delay=3, icon="kill"),
+		list(mode_name = "Rubber Rounds (Switch)", projectile_type=/obj/item/projectile/bullet/pistol_35/rubber, fire_sound='sound/weapons/guns/fire/9mm_pistol.ogg', mode_type = /datum/firemode/automatic, fire_delay = 1.3  , icon="fuller"),
+		list(mode_name = "Hollowpoint Rounds (Switch)", projectile_type=/obj/item/projectile/bullet/pistol_35/lethal, fire_sound='sound/weapons/guns/fire/9mm_pistol.ogg',  mode_type = /datum/firemode/automatic, fire_delay = 1.15, icon="fuller")
+	)
 	charge_meter = FALSE
 
 /obj/item/gun/energy/smg

--- a/code/modules/research/designs/robot_parts.dm
+++ b/code/modules/research/designs/robot_parts.dm
@@ -162,3 +162,15 @@
 	name = "Satchel of holding equipment upgrade"
 	desc = "Allows for the construction of lethal upgrades for sec-based bots."
 	build_path = /obj/item/borg/upgrade/satchel_of_holding_for_borgs
+
+//I'd shove these elsewhere, but it's probably good to keep them together incase it needs adjustment/disabling
+
+/datum/design/research/item/posibrain
+	name = "Positronic Brain"
+	desc = "Produces a single-use positronic intelligence holder. When activated, it will attempt to generate a personality; and if successful, permanently engraves it into the storage medium."
+	build_path = /obj/item/device/mmi/digital/posibrain
+
+/datum/design/research/item/borismodule
+	name = "ISHAEK Remote Control Chip"
+	desc = "Allows for remote AI control when inserted into an empty shell. Experimental."
+	build_path = /obj/item/borg/upgrade/boris

--- a/code/modules/research/nodes/robotics.dm
+++ b/code/modules/research/nodes/robotics.dm
@@ -302,6 +302,7 @@
 							/datum/design/research/item/mmi_radio,
 							/datum/design/research/item/intellicard,
 							/datum/design/research/item/paicard,
+							/datum/design/research/item/posibrain, //Trilby moment
 							/datum/design/research/circuit/robocontrol
 							)
 
@@ -320,7 +321,8 @@
 
 	unlocks_designs = list(
 							/datum/design/research/circuit/aicore,
-							/datum/design/research/circuit/aiupload
+							/datum/design/research/circuit/aiupload,
+							/datum/design/research/item/borismodule
 							)
 
 /datum/technology/artificial_intelligence_laws

--- a/modular_sojourn/BORISmodules/boris.dm
+++ b/modular_sojourn/BORISmodules/boris.dm
@@ -1,0 +1,13 @@
+/obj/item/borg/upgrade/boris
+	name = "ISHAEK Remote Control Chip"
+	desc = "A custom piece of hardware; designed in-house by V.A Science in response to the ongoing, wasteful practices of having to manually override shell safties. Functions as a means to produce more AI shells -\
+	Though due to the Ad-hoc nature of how it functions, it does not correctly secure the shells against foreign AI intrusion." //You can currently hop in any unoccupied AI shell if you somehow make one off the colony
+	icon_state = "cyborg_upgrade1"
+	w_class = ITEM_SIZE_NORMAL
+	origin_tech = list(TECH_BIO = 3)
+	matter = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 3)
+
+/obj/item/borg/upgrade/boris/action(var/mob/living/silicon/robot/R)
+	if(R)
+		to_chat(usr, "This module is only intended to be inserted into inactive shells!")
+		return FALSE

--- a/modular_sojourn/BORISmodules/boris.dm
+++ b/modular_sojourn/BORISmodules/boris.dm
@@ -1,7 +1,7 @@
 /obj/item/borg/upgrade/boris
 	name = "ISHAEK Remote Control Chip"
-	desc = "A custom piece of hardware; designed in-house by V.A Science in response to the ongoing, wasteful practices of having to manually override shell safties. Functions as a means to produce more AI shells -\
-	Though due to the Ad-hoc nature of how it functions, it does not correctly secure the shells against foreign AI intrusion." //You can currently hop in any unoccupied AI shell if you somehow make one off the colony
+	desc = "A custom piece of hardware; designed in-house by V.A Science in response to the ongoing, wasteful practices of having to manually override shell safeties. Functions as a means to produce more AI shells -\
+	 Though due to the Ad-hoc nature of how it functions, it does not correctly secure the shells against foreign AI intrusion." //You can currently hop in any unoccupied AI shell if you somehow make one off the colony
 	icon_state = "cyborg_upgrade1"
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_BIO = 3)

--- a/sojourn-iskhod.dme
+++ b/sojourn-iskhod.dme
@@ -3566,6 +3566,7 @@
 #include "modular_sojourn\Borers\__ADMIN SHIT\objective.dm"
 #include "modular_sojourn\Borers\__ADMIN SHIT\organs.dm"
 #include "modular_sojourn\Borers\__ADMIN SHIT\roleset.dm"
+#include "modular_sojourn\BORISmodules\boris.dm"
 #include "modular_sojourn\cardgame_2\cardgame_2.dm"
 #include "modular_sojourn\cardgame_2\cardholder.dm"
 #include "modular_sojourn\cardgame_2\cardpacks_and_spawner.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. I refuse to use the dogshit git template here because it's confusing

## What It does
Adds BORIS-like modules behind AI research, price is subject to change. When used on an incomplete cyborg shell missing a brain, it will function as a MMI that simply sets the stat to 2 and creates an empty vessel.
Changes the Integrated STS, Integrated Gladstone, and Integrated Glock to be more useful (it was literally faster to beat things to death with my security omnitool than it was to wait for the weapons to recharge) - Subject to balance changes in future
Readds Posibrains.

## Changelog
:cl:
fix: Posibrains back in research. Trilby removed them ages ago and forgot to remove the description for them, so back they go
add:  ISHAEK Remote Control Chip - Our Version of the BORIS module
tweak: Robot weapons given experimental buffs to see if they stop feeling god awful to use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
